### PR TITLE
Fix typo at line 20 of intro in documentation, author name was misspelled

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,7 +17,7 @@ realm = "shared"
 
 [dependencies]
 Signal = "sleitnick/signal@^1.0"
-TableUtil = "slietnick/table-util@^1.0"
+TableUtil = "sleitnick/table-util@^1.0"
 ```
 
 To install these dependencies, run `wally install` within your project. Wally will create a Package folder in your directory with the installed dependencies.


### PR DESCRIPTION
At the example TableUtil dependency, sleitnick was misspelled to "slietnick"