### PR TITLE
Fix `Signal:Fire` resuming an already resumed thread

### DIFF
--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -222,7 +222,10 @@ function Signal:Fire(...)
 			if not freeRunnerThread then
 				freeRunnerThread = coroutine.create(runEventHandlerInFreeThread)
 			end
-			task.spawn(freeRunnerThread, item._fn, ...)
+					
+			if coroutine.status(freeRunnerThread) == "suspended" then
+				task.spawn(freeRunnerThread, item._fn, ...)
+			end
 		end
 		item = item._next
 	end


### PR DESCRIPTION
This fixes an issue where `Signal:Fire` attempts to resume a thread that is already resumed.