### PR TITLE
Implement type packs and use table.freeze for Signals

### DIFF
--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -24,32 +24,6 @@
 --   sleitnick - August 3rd, 2021 - Modified for Knit.                        --
 -- -----------------------------------------------------------------------------
 
--- -----------------------------------------------------------------------------
---               Batched Yield-Safe Signal Implementation                     --
--- This is a Signal class which has effectively identical behavior to a       --
--- normal RBXScriptSignal, with the only difference being a couple extra      --
--- stack frames at the bottom of the stack trace when an error is thrown.     --
--- This implementation caches runner coroutines, so the ability to yield in   --
--- the signal handlers comes at minimal extra cost over a naive signal        --
--- implementation that either always or never spawns a thread.                --
---                                                                            --
--- API:                                                                       --
---   local Signal = require(THIS MODULE)                                      --
---   local sig = Signal.new()                                                 --
---   local connection = sig:Connect(function(arg1, arg2, ...) ... end)        --
---   sig:Fire(arg1, arg2, ...)                                                --
---   connection:Disconnect()                                                  --
---   sig:DisconnectAll()                                                      --
---   local arg1, arg2, ... = sig:Wait()                                       --
---                                                                            --
--- License:                                                                   --
---   Licensed under the MIT license.                                          --
---                                                                            --
--- Authors:                                                                   --
---   stravant - July 31st, 2021 - Created the file.                           --
---   sleitnick - August 3rd, 2021 - Modified for Knit.                        --
--- -----------------------------------------------------------------------------
-
 export type Type<T...> = {
 	Connect: (Type<T...>, func: (T...) -> ()) -> Connection<T...>,
 	Fire: (Type<T...>, T...) -> (),


### PR DESCRIPTION
[This should be blocked until Roblox LSP allows type packs. This works in Studio's LSP, but not vscode yet.]

This pull request introduces types to signals. You can specify them like so:

```lua
local OnChanged: Signal.SignalType<boolean, any> = Signal.new()
```

or alternatively the language server will try infer.

This is incredibly useful when dealing with many signals at once, and would help people used to typed languages tremendously.

This pull request also changes the way tables are set to strict by using `table.freeze` instead of metamethods.