### PR TITLE
Fix shake sustain

### DIFF
--- a/modules/shake/init.lua
+++ b/modules/shake/init.lua
@@ -343,7 +343,7 @@ function Shake:Update(): (Vector3, Vector3, boolean)
 	if dur < self.FadeInTime then
 		multiplierFadeIn = dur / self.FadeInTime
 	end
-	if dur > self.FadeInTime + self.SustainTime then
+	if not self.Sustain and dur > self.FadeInTime + self.SustainTime then
 		multiplierFadeOut = 1 - (dur - self.FadeInTime - self.SustainTime) / self.FadeOutTime
 		if (not self.Sustain) and dur >= self.FadeInTime + self.SustainTime + self.FadeOutTime then
 			done = true

--- a/modules/shake/wally.toml
+++ b/modules/shake/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/shake"
 description = "Shake class for making things shake"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
The `Sustain` property of the Shake module wasn't working properly. This was caused due to the code trying to fade out the shake without checking if it should be sustaining. The result was a runaway multiplier which caused the shake to get progressively more intense over time.

This PR fixes it by adding in a check to see if it is sustaining before trying to fade out. The result is that sustained shakes keep a constant intensity as expected.