### PR TITLE
Fix Comm middleware arg count

### DIFF
--- a/modules/comm/Client/ClientRemoteSignal.lua
+++ b/modules/comm/Client/ClientRemoteSignal.lua
@@ -39,6 +39,7 @@ function ClientRemoteSignal.new(re: RemoteEvent, inboundMiddleware: Types.Client
 				if not middlewareResult[1] then
 					return
 				end
+				args.n = #args
 			end
 			self._signal:Fire(table.unpack(args, 1, args.n))
 		end)
@@ -55,6 +56,7 @@ function ClientRemoteSignal:_processOutboundMiddleware(...: any)
 		if not middlewareResult[1] then
 			return table.unpack(middlewareResult, 2, middlewareResult.n)
 		end
+		args.n = #args
 	end
 	return table.unpack(args, 1, args.n)
 end

--- a/modules/comm/Client/init.lua
+++ b/modules/comm/Client/init.lua
@@ -19,6 +19,7 @@ function Client.GetFunction(parent: Instance, name: string, usePromise: boolean,
 			if not middlewareResult[1] then
 				return table.unpack(middlewareResult, 2, middlewareResult.n)
 			end
+			args.n = #args
 		end
 		return table.unpack(args, 1, args.n)
 	end
@@ -40,6 +41,7 @@ function Client.GetFunction(parent: Instance, name: string, usePromise: boolean,
 							if not middlewareResult[1] then
 								return table.unpack(middlewareResult, 2, middlewareResult.n)
 							end
+							res.n = #res
 						end
 						resolve(table.unpack(res, 1, res.n))
 					else
@@ -60,6 +62,7 @@ function Client.GetFunction(parent: Instance, name: string, usePromise: boolean,
 					if not middlewareResult[1] then
 						return table.unpack(middlewareResult, 2, middlewareResult.n)
 					end
+					res.n = #res
 				end
 				return table.unpack(res, 1, res.n)
 			end

--- a/modules/comm/Server/RemoteSignal.lua
+++ b/modules/comm/Server/RemoteSignal.lua
@@ -44,6 +44,7 @@ function RemoteSignal.new(parent: Instance, name: string, inboundMiddleware: Typ
 				if not middlewareResult[1] then
 					return
 				end
+				args.n = #args
 			end
 			self._signal:Fire(player, table.unpack(args, 1, args.n))
 		end)
@@ -78,6 +79,7 @@ function RemoteSignal:_processOutboundMiddleware(player: Player?, ...: any)
 		if not middlewareResult[1] then
 			return table.unpack(middlewareResult, 2, middlewareResult.n)
 		end
+		args.n = #args
 	end
 	return table.unpack(args, 1, args.n)
 end

--- a/modules/comm/Server/init.lua
+++ b/modules/comm/Server/init.lua
@@ -49,6 +49,7 @@ function Server.BindFunction(parent: Instance, name: string, func: Types.FnBind,
 			if not middlewareResult[1] then
 				return table.unpack(middlewareResult, 2, middlewareResult.n)
 			end
+			args.n = #args
 		end
 		return table.unpack(args, 1, args.n)
 	end
@@ -60,6 +61,7 @@ function Server.BindFunction(parent: Instance, name: string, func: Types.FnBind,
 				if not middlewareResult[1] then
 					return table.unpack(middlewareResult, 2, middlewareResult.n)
 				end
+				args.n = #args
 			end
 			return ProcessOutbound(player, func(player, table.unpack(args, 1, args.n)))
 		end
@@ -72,6 +74,7 @@ function Server.BindFunction(parent: Instance, name: string, func: Types.FnBind,
 				if not middlewareResult[1] then
 					return table.unpack(middlewareResult, 2, middlewareResult.n)
 				end
+				args.n = #args
 			end
 			return func(player, table.unpack(args, 1, args.n))
 		end

--- a/modules/comm/wally.toml
+++ b/modules/comm/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/comm"
 description = "Comm library for remote communication"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
Comm middleware can change the number of args passed inbound/outbound, but Comm wasn't resetting `n` within the packed arg table. This PR fixes this by setting `n` to the size of the arg table every time after a middleware function is fired with the arg table.