### PR TITLE
Trove promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@
 | [TableUtil](https://sleitnick.github.io/RbxUtil/api/TableUtil) | `TableUtil = "sleitnick/table-util@1.1.1"` | Table utility functions |
 | [TaskQueue](https://sleitnick.github.io/RbxUtil/api/TaskQueue) | `TaskQueue = "sleitnick/task-queue@0.1.0"` | Batches tasks that occur on the same execution step |
 | [Timer](https://sleitnick.github.io/RbxUtil/api/Timer) | `Timer = "sleitnick/timer@1.1.1"` | Timer class |
-| [Trove](https://sleitnick.github.io/RbxUtil/api/Trove) | `Trove = "sleitnick/trove@0.3.0"` | Trove class for tracking and cleaning up objects |
+| [Trove](https://sleitnick.github.io/RbxUtil/api/Trove) | `Trove = "sleitnick/trove@0.4.0"` | Trove class for tracking and cleaning up objects |
 | [WaitFor](https://sleitnick.github.io/RbxUtil/api/WaitFor) | `WaitFor = "sleitnick/wait-for@0.2.0"` | WaitFor class for awaiting instances |

--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -30,7 +30,14 @@ local function GetObjectCleanupFunction(object, cleanupMethod)
 			return "Disconnect"
 		end
 	end
-	error("Failed to get cleanup function for object " .. t .. ": " .. tostring(object))
+	error("Failed to get cleanup function for object " .. t .. ": " .. tostring(object), 3)
+end
+
+
+local function AssertPromiseLike(object)
+	if type(object) ~= "table" or type(object.getStatus) ~= "function" or type(object.finally) ~= "function" or type(object.cancel) ~= "function" then
+		error("Did not receive a Promise as an argument", 3)
+	end
 end
 
 
@@ -197,6 +204,7 @@ end
 	:::
 ]=]
 function Trove:AddPromise(promise)
+	AssertPromiseLike(promise)
 	if promise:getStatus() == "Started" then
 		promise:finally(function()
 			return self:_findAndRemoveFromObjects(promise, false)

--- a/modules/trove/wally.toml
+++ b/modules/trove/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/trove"
 description = "Trove class for tracking and cleaning up objects"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
Adds the `AddPromise` method to Trove, allowing developers to give promises to a trove. A trove attempts to clean up a promise by calling its `cancel` method.

```lua
trove:AddPromise(doSomethingThatReturnsAPromise())
	:andThen(function()
		print("Done")
	end)
-- Will cancel the above promise (assuming it didn't resolve immediately)
trove:Clean()

local p = trove:AddPromise(doSomethingThatReturnsAPromise())
-- Will also cancel the promise
trove:Remove(p)
```

This PR also includes #63 which uses the new `Destroying` event for the `AttachToInstance` method.