### PR TITLE
Add ConnectOnce to Signal

### DIFF
--- a/modules/signal/init.spec.lua
+++ b/modules/signal/init.spec.lua
@@ -100,6 +100,22 @@ return function()
 
 	end)
 
+	describe("ConnectOnce", function()
+
+		it("should only capture first fire", function()
+			local value
+			local c = signal:ConnectOnce(function(v)
+				value = v
+			end)
+			expect(c.Connected).to.equal(true)
+			signal:Fire(10)
+			expect(c.Connected).to.equal(false)
+			signal:Fire(20)
+			expect(value).to.equal(10)
+		end)
+		
+	end)
+
 	describe("Wait", function()
 
 		it("should be able to wait for a signal to fire", function()

--- a/modules/signal/wally.toml
+++ b/modules/signal/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/signal"
 description = "Signal class"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
ConnectOnce works the same as Connect, but disconnects itself after the first time it is triggered.

```lua
signal:ConnectOnce(function(...)
   print(...)
end)

signal:Fire("Hello") -- Connection will receive this
signal:Fire("Goodbye") -- Connection will NOT receive this (disconnected)
```