### PR TITLE
update to make requiring input classes easier

### DIFF
--- a/modules/input/init.lua
+++ b/modules/input/init.lua
@@ -16,12 +16,18 @@
 	Require the desired input modules to get started:
 
 	```lua
-	local PreferredInput = require(Packages.Input.PreferredInput)
-	local Mouse = require(Packages.Input.Mouse)
-	local Keyboard = require(Packages.Input.Keyboard)
-	local Touch = require(Packages.Input.Touch)
-	local Gamepad = require(Packages.Input.Gamepad)
+	local PreferredInput = require(Packages.Input).PreferredInput
+	local Mouse = require(Packages.Input).Mouse
+	local Keyboard = require(Packages.Input).Keyboard
+	local Touch = require(Packages.Input).Touch
+	local Gamepad = require(Packages.Input).Gamepad
 	```
 ]=]
 
-return nil
+return {
+	PreferredInput = require(script.PreferredInput),
+	Mouse = require(script.Mouse)
+	Keyboard = require(script.Keyboard)
+	Touch = require(script.Touch)
+	Gamepad = require(script.Gamepad)
+}


### PR DESCRIPTION
Currently, it's impossible to do this `local Mouse = require(Packages.Input.Mouse)` or this `local Keyboard = require(Packages.Input.Keyboard)` because `Packages.Input` does not point to the file that contains the input classes but the file that requires the file that contains the input classes.