### PR TITLE
Input wally support.

### DIFF
--- a/modules/loader/init.lua
+++ b/modules/loader/init.lua
@@ -8,8 +8,9 @@
 
 	Loads all ModuleScripts within the given parent.
 
-	Loader.LoadChildren(parent: Instance): module[]
-	Loader.LoadDescendants(parent: Instance): module[]
+	Loader.LoadChildren(parent: Instance, returnDictionary: boolean?): module[]
+	Loader.LoadDescendants(parent: Instance, returnDictionary: boolean?): module[]
+	Loader.LoadInFolders(parent: Instance, returnDictionary: boolean?): module[]
 
 --]]
 
@@ -21,21 +22,26 @@
 local Loader = {}
 
 type Module = {}
-type Modules = {Module}
+type ModuleName = string
+type DictionaryOfModules = { ModuleName: Module }
+type ArrayOfModules = { Module }
 
+local function loadModulesIn(
+	parent: Instance,
+	deep: boolean?,
+	returnDictionary: boolean?
+): ArrayOfModules | DictionaryOfModules
+	local instances = if deep then parent:GetDescendants() else parent:GetChildren()
+	local modules: ArrayOfModules | DictionaryOfModules = {}
+	for _, instance in ipairs(instances) do
+		if instance:IsA("ModuleScript") then
+			local m: Module = require(instance)
 
---[=[
-	Requires all children ModuleScripts
-
-	@param parent Instance -- Parent to scan
-	@return {ModuleScript} -- Array of required modules
-]=]
-function Loader.LoadChildren(parent: Instance): Modules
-	local modules: Modules = {}
-	for _,child in ipairs(parent:GetChildren()) do
-		if child:IsA("ModuleScript") then
-			local m = require(child)
-			table.insert(modules, m)
+			if returnDictionary then
+				modules[instance.Name] = m
+			else
+				table.insert(modules, m)
+			end
 		end
 	end
 	return modules
@@ -43,20 +49,73 @@ end
 
 
 --[=[
+	Only requires ModuleScripts that are parented to folders. Especially useful
+	when you have ModuleScripts parented to ModuleScripts that shouldn't be
+	required from an external source other than the parent ModuleScript.
+
+	```lua
+	-- Can return arrays:
+	local systems = Loader.LoadInFolders(script.Systems)
+
+	scheduleSystems(systems)
+
+	-- Can also return dictionaries:
+	local humanoidStateCalculationModules = Loader.LoadInFolders(script.HumanoidStateModules, true)
+
+	for stateName, module in pairs(humanoidStateCalculationModules) do
+		debug.profilebegin(string.format("Calculate Is%s", stateName))
+		module.Calculate()
+		debug.profileend()
+	end
+	```
+
+	@param parent Instance -- Parent to scan
+	@param returnDictionary boolean -- If the modules returned should be a dictionary
+	@return ArrayOfModules | DictionaryOfModules -- Array or dictionary of required modules
+]=]
+function Loader.LoadInFolders(parent: Instance, returnDictionary: boolean?): ArrayOfModules | DictionaryOfModules
+	local modules: ArrayOfModules | DictionaryOfModules = {}
+	local function loadDeep(instance: Instance)
+		local childModules = loadModulesIn(instance, false, returnDictionary)
+		for key: ModuleName | number, module in pairs(childModules) do
+			if returnDictionary then
+				modules[key] = module
+			else
+				table.insert(modules, module)
+			end
+		end
+		for _, child in ipairs(instance:GetChildren()) do
+			if child:IsA("Folder") then
+				loadDeep(child)
+			end
+		end
+	end
+	loadDeep(parent)
+	return modules
+end
+
+
+--[=[
+	Requires all children ModuleScripts
+
+	@param parent Instance -- Parent to scan
+	@param returnDictionary boolean -- If the modules returned should be a dictionary
+	@return ArrayOfModules | DictionaryOfModules -- Array or dictionary of required modules
+]=]
+function Loader.LoadChildren(parent: Instance, returnDictionary: boolean?): ArrayOfModules | DictionaryOfModules
+	return loadModulesIn(parent, false, returnDictionary)
+end
+
+
+--[=[
 	Requires all descendant ModuleScripts
 
 	@param parent Instance -- Parent to scan
-	@return {ModuleScript} -- Array of required modules
+	@param returnDictionary boolean -- If the modules returned should be a dictionary
+	@return ArrayOfModules | DictionaryOfModules -- Array or dictionary of required modules
 ]=]
-function Loader.LoadDescendants(parent: Instance): Modules
-	local modules: Modules = {}
-	for _,descendant in ipairs(parent:GetDescendants()) do
-		if descendant:IsA("ModuleScript") then
-			local m = require(descendant)
-			table.insert(modules, m)
-		end
-	end
-	return modules
+function Loader.LoadDescendants(parent: Instance, returnDictionary: boolean?): ArrayOfModules | DictionaryOfModules
+	return loadModulesIn(parent, true, returnDictionary)
 end
 
 


### PR DESCRIPTION
Input should return a table for wally support. The only way to access currently is via `Packages._Index[folder].input.Module` when installing the package via wally.