### PR TITLE
Add TableUtil.Merge function

### DIFF
--- a/modules/table-util/init.lua
+++ b/modules/table-util/init.lua
@@ -62,6 +62,37 @@ end
 
 --[=[
 	@within TableUtil
+	@function Merge
+	@param a table -- Table to be merged into
+	@param b table -- Table to merged with table `a`
+	@param copy boolean? -- Whether to return a new table or merge into table a
+	@return table
+	
+	Merges table `b` into table `a`. Can also return a new table without affecting
+	the original tables.
+]=]
+
+local function Merge (a: Table, b: Table, copy: boolean?): Table
+	if (copy) then
+		local tCopy = Copy(a, true)
+		for k,v in pairs(b)  do
+			if (type(v) == "table") then
+				tCopy[k] = Copy(v, true)
+			end
+		end
+		return tCopy
+	else
+		for k,v in pairs(b)  do
+			if (type(v) == "table") then
+				a[k] = Copy(v, true)
+			end
+		end
+		return a
+	end
+end
+		
+--[=[
+	@within TableUtil
 	@function Sync
 	@param srcTbl table -- Source table
 	@param templateTbl table -- Template table

--- a/modules/table-util/init.lua
+++ b/modules/table-util/init.lua
@@ -60,18 +60,18 @@ local function Copy(t: Table, deep: boolean?): Table
 	return DeepCopy(t)
 end
 
+
 --[=[
 	@within TableUtil
 	@function Merge
 	@param a table -- Table to be merged into
-	@param b table -- Table to merged with table `a`
+	@param b table -- Table to merged with first table
 	@param copy boolean? -- Whether to return a new table or merge into table a
 	@return table
 	
 	Merges table `b` into table `a`. Can also return a new table without affecting
 	the original tables.
 ]=]
-
 local function Merge (a: Table, b: Table, copy: boolean?): Table
 	if copy then
 		local tCopy = Copy(a, true)
@@ -90,7 +90,8 @@ local function Merge (a: Table, b: Table, copy: boolean?): Table
 		return a
 	end
 end
-		
+
+
 --[=[
 	@within TableUtil
 	@function Sync

--- a/modules/table-util/init.lua
+++ b/modules/table-util/init.lua
@@ -73,17 +73,17 @@ end
 ]=]
 
 local function Merge (a: Table, b: Table, copy: boolean?): Table
-	if (copy) then
+	if copy then
 		local tCopy = Copy(a, true)
 		for k,v in pairs(b)  do
-			if (type(v) == "table") then
+			if type(v) == "table" then
 				tCopy[k] = Copy(v, true)
 			end
 		end
 		return tCopy
 	else
 		for k,v in pairs(b)  do
-			if (type(v) == "table") then
+			if type(v) == "table" then
 				a[k] = Copy(v, true)
 			end
 		end

--- a/modules/table-util/init.lua
+++ b/modules/table-util/init.lua
@@ -925,6 +925,7 @@ local function DecodeJSON(str: string): any
 end
 
 TableUtil.Copy = Copy
+TableUtil.Merge = Merge
 TableUtil.Sync = Sync
 TableUtil.Reconcile = Reconcile
 TableUtil.SwapRemove = SwapRemove


### PR DESCRIPTION
This would add a TableUtil.Merge function, which joins the second table into the first table (deeply). Includes argument for deep copying the first table so that returned value is an entirely new table. 