### PR TITLE
Trove improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@
 | [PID](https://sleitnick.github.io/RbxUtil/api/PID) | `PID = "sleitnick/pid@1.0.1"` | PID Controller class |
 | [Ser](https://sleitnick.github.io/RbxUtil/api/Ser) | `Ser = "sleitnick/ser@1.0.4"` | Ser class for serialization and deserialization |
 | [Shake](https://sleitnick.github.io/RbxUtil/api/Shake) | `Shake = "sleitnick/shake@0.1.5"` | Shake class for making things shake |
-| [Signal](https://sleitnick.github.io/RbxUtil/api/Signal) | `Signal = "sleitnick/signal@1.1.0"` | Signal class |
+| [Signal](https://sleitnick.github.io/RbxUtil/api/Signal) | `Signal = "sleitnick/signal@1.2.0"` | Signal class |
 | [Silo](https://sleitnick.github.io/RbxUtil/api/Silo) | `Silo = "sleitnick/silo@0.1.0"` | State container class |
 | [Streamable](https://sleitnick.github.io/RbxUtil/api/Streamable) | `Streamable = "sleitnick/streamable@1.2.3"` | Streamable class and StreamableUtil |
 | [Symbol](https://sleitnick.github.io/RbxUtil/api/Symbol) | `Symbol = "sleitnick/symbol@2.0.0"` | Symbol |
-| [TableUtil](https://sleitnick.github.io/RbxUtil/api/TableUtil) | `TableUtil = "sleitnick/table-util@1.1.3"` | Table utility functions |
+| [TableUtil](https://sleitnick.github.io/RbxUtil/api/TableUtil) | `TableUtil = "sleitnick/table-util@1.1.4"` | Table utility functions |
 | [TaskQueue](https://sleitnick.github.io/RbxUtil/api/TaskQueue) | `TaskQueue = "sleitnick/task-queue@0.1.0"` | Batches tasks that occur on the same execution step |
 | [Timer](https://sleitnick.github.io/RbxUtil/api/Timer) | `Timer = "sleitnick/timer@1.1.1"` | Timer class |
-| [Trove](https://sleitnick.github.io/RbxUtil/api/Trove) | `Trove = "sleitnick/trove@0.4.0"` | Trove class for tracking and cleaning up objects |
+| [Trove](https://sleitnick.github.io/RbxUtil/api/Trove) | `Trove = "sleitnick/trove@0.4.1"` | Trove class for tracking and cleaning up objects |
 | [WaitFor](https://sleitnick.github.io/RbxUtil/api/WaitFor) | `WaitFor = "sleitnick/wait-for@0.2.1"` | WaitFor class for awaiting instances |

--- a/modules/input/Keyboard.lua
+++ b/modules/input/Keyboard.lua
@@ -16,7 +16,7 @@ local UserInputService = game:GetService("UserInputService")
 	The Keyboard class is part of the Input package.
 
 	```lua
-	local Keyboard = require(packages.Input).Keyboard
+	local Keyboard = require(packages.Input.Keyboard)
 	```
 ]=]
 local Keyboard = {}
@@ -60,7 +60,7 @@ function Keyboard.new()
 	self._trove = Trove.new()
 	self.KeyDown = self._trove:Construct(Signal)
 	self.KeyUp = self._trove:Construct(Signal)
-	self.KeysDown = {}
+	self.State = {}
 	self:_setup()
 	return self
 end
@@ -75,7 +75,7 @@ end
 	```
 ]=]
 function Keyboard:IsKeyDown(keyCode: Enum.KeyCode): boolean
-	return self.KeysDown[keyCode] ~= nil
+	return self.State[Keyboard] == true
 end
 
 
@@ -113,7 +113,7 @@ function Keyboard:_setup()
 	self._trove:Connect(UserInputService.InputBegan, function(input, processed)
 		if processed then return end
 		if input.UserInputType == Enum.UserInputType.Keyboard then
-			self.KeysDown[input.KeyCode] = true
+			self.State[input.KeyCode] = true
 			self.KeyDown:Fire(input.KeyCode)
 		end
 	end)
@@ -121,7 +121,7 @@ function Keyboard:_setup()
 	self._trove:Connect(UserInputService.InputEnded, function(input, processed)
 		if processed then return end
 		if input.UserInputType == Enum.UserInputType.Keyboard then
-			self.KeysDown[input.KeyCode] = nil
+			self.State[input.KeyCode] = nil
 			self.KeyUp:Fire(input.KeyCode)
 		end
 	end)

--- a/modules/input/Keyboard.lua
+++ b/modules/input/Keyboard.lua
@@ -60,6 +60,7 @@ function Keyboard.new()
 	self._trove = Trove.new()
 	self.KeyDown = self._trove:Construct(Signal)
 	self.KeyUp = self._trove:Construct(Signal)
+	self.State = {}
 	self:_setup()
 	return self
 end
@@ -74,7 +75,7 @@ end
 	```
 ]=]
 function Keyboard:IsKeyDown(keyCode: Enum.KeyCode): boolean
-	return UserInputService:IsKeyDown(keyCode)
+	return self.State[keyCode] == true
 end
 
 
@@ -112,6 +113,7 @@ function Keyboard:_setup()
 	self._trove:Connect(UserInputService.InputBegan, function(input, processed)
 		if processed then return end
 		if input.UserInputType == Enum.UserInputType.Keyboard then
+			self.State[input.KeyCode] = true
 			self.KeyDown:Fire(input.KeyCode)
 		end
 	end)
@@ -119,6 +121,7 @@ function Keyboard:_setup()
 	self._trove:Connect(UserInputService.InputEnded, function(input, processed)
 		if processed then return end
 		if input.UserInputType == Enum.UserInputType.Keyboard then
+			self.State[input.KeyCode] = nil
 			self.KeyUp:Fire(input.KeyCode)
 		end
 	end)

--- a/modules/input/Keyboard.lua
+++ b/modules/input/Keyboard.lua
@@ -60,7 +60,6 @@ function Keyboard.new()
 	self._trove = Trove.new()
 	self.KeyDown = self._trove:Construct(Signal)
 	self.KeyUp = self._trove:Construct(Signal)
-	self.State = {}
 	self:_setup()
 	return self
 end
@@ -75,7 +74,7 @@ end
 	```
 ]=]
 function Keyboard:IsKeyDown(keyCode: Enum.KeyCode): boolean
-	return self.State[Keyboard] == true
+	return UserInputService:IsKeyDown(keyCode)
 end
 
 
@@ -113,7 +112,6 @@ function Keyboard:_setup()
 	self._trove:Connect(UserInputService.InputBegan, function(input, processed)
 		if processed then return end
 		if input.UserInputType == Enum.UserInputType.Keyboard then
-			self.State[input.KeyCode] = true
 			self.KeyDown:Fire(input.KeyCode)
 		end
 	end)
@@ -121,7 +119,6 @@ function Keyboard:_setup()
 	self._trove:Connect(UserInputService.InputEnded, function(input, processed)
 		if processed then return end
 		if input.UserInputType == Enum.UserInputType.Keyboard then
-			self.State[input.KeyCode] = nil
 			self.KeyUp:Fire(input.KeyCode)
 		end
 	end)


### PR DESCRIPTION
Updated Trove to include a variety of quality-of-life changes, including allowing the user to easily use ``signal:Once`` with the new ``ConnectOnce`` method, allowing a trove to be attached to characters and humanoids, utilizing ``task.cancel`` over ``coroutine.cancel`` as to allow for the user to utilize **BOTH** the task and coroutine libraries, and clearing tables without any destroy or disconnect methods through ``table.clear`` and setting its metatable to ``nil``.