### PR TITLE
Use `catch` on promise (for `Trove:AddPromise`)

### DIFF
--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -224,7 +224,7 @@ function Trove:AddPromise(promise)
 				return
 			end
 			self:_findAndRemoveFromObjects(promise, false)
-		end)
+		end):catch(function() end)
 		self:Add(promise, "cancel")
 	end
 	return promise


### PR DESCRIPTION
Currently, `Trove:AddPromise` does not use `catch` on the passed promise - which means if the promise rejects, an additional error will be thrown (even if the rejection is handled by the user):

```lua
local promise = Promise.new()
trove:AddPromise(promise) -- line 2

promise:andThen(function()

end):catch(function()

end)
-- If the promise rejects, the Promise lib will throw the "Unhandled promise rejection" warning, 
-- due to trove... remove line 2 and the lib won't throw the warning
```