### PR TITLE
Type support for Signal

### DIFF
--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -65,6 +65,33 @@ end
 	```
 ]=]
 
+-- Signal types
+type Connection = {
+	Disconnect: (self: any) -> (),
+	Destroy: (self: any) -> (),
+}
+
+type HandlerListHead = {
+	Connected: boolean,
+	_fn: () -> (),
+	_next: boolean,
+	_signal: {
+		_handlerListHead: any,
+	},
+}
+
+export type Signal<T...> = {
+	Fire: (self: Signal<T...>, T...) -> (),
+	FireDeferred: (self: Signal<T...>, T...) -> (),
+	Connect: (self: any, fn: (T...) -> ()) -> Connection,
+	Once: (self: any, fn: (T...) -> ()) -> Connection,
+	ConnectOnce: (self: any, fn: (T...) -> ()) -> Connection,
+	DisconnectAll: (self: any) -> (),
+	GetConnections: (self: any) -> HandlerListHead,
+	Destroy: (self: any) -> (),
+	Wait: (self: any) -> T...,
+}
+
 -- Connection class
 local Connection = {}
 Connection.__index = Connection
@@ -144,7 +171,7 @@ Signal.__index = Signal
 
 	@return Signal
 ]=]
-function Signal.new()
+function Signal.new<T...>(): Signal<T...>
 	local self = setmetatable({
 		_handlerListHead = false,
 		_proxyHandler = nil,

--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -66,30 +66,21 @@ end
 ]=]
 
 -- Signal types
-type Connection = {
-	Disconnect: (self: any) -> (),
-	Destroy: (self: any) -> (),
-}
 
-type HandlerListHead = {
-	Connected: boolean,
-	_fn: () -> (),
-	_next: boolean,
-	_signal: {
-		_handlerListHead: any,
-	},
+type Connection = {
+	Disconnect: (self: Signal<T...>) -> (),
+	Destroy: (self: Signal<T...>) -> (),
 }
 
 export type Signal<T...> = {
 	Fire: (self: Signal<T...>, T...) -> (),
 	FireDeferred: (self: Signal<T...>, T...) -> (),
-	Connect: (self: any, fn: (T...) -> ()) -> Connection,
-	Once: (self: any, fn: (T...) -> ()) -> Connection,
-	ConnectOnce: (self: any, fn: (T...) -> ()) -> Connection,
-	DisconnectAll: (self: any) -> (),
-	GetConnections: (self: any) -> HandlerListHead,
-	Destroy: (self: any) -> (),
-	Wait: (self: any) -> T...,
+	Connect: (self: Connection, fn: (T...) -> ()) -> Connection,
+	Once: (self: Connection, fn: (T...) -> ()) -> Connection,
+	DisconnectAll: (self: Signal<T...>) -> (),
+	GetConnections: (self: Signal<T...>) -> { Connection },
+	Destroy: (self: Signal<T...>) -> (),
+	Wait: (self: Signal<T...>) -> T...,
 }
 
 -- Connection class


### PR DESCRIPTION
Sleitnick shared that he did the type support before, but he didn't publish it, so I wanted to write it again and share it myself.

# Example
```lua
local Signal = require(game:GetService("ReplicatedStorage").Signal)

local testSignal = Signal.new()

testSignal:Fire(1, "kra", 5)

testSignal:Connect(function(...)
	print(...)
end)
```