### PR TITLE
Trove Improvements

### DIFF
--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -220,7 +220,7 @@ end
 	trove that will call `CollectionService:UnbindAction` on cleanup.
 
 	```lua
-	trove:BindToRenderStep("Test", Enum.RenderPriority.Last.Value, function(dt)
+	trove:BindAction("Test", Enum.RenderPriority.Last.Value, function(dt)
 		-- Do something
 	end)
 	```
@@ -233,7 +233,7 @@ function Trove:BindAction(name: string, createMobileButton: boolean, ...: Enum.K
 		error("Cannot call trove:BindAction() on the server", 2)
 	end
 
-	ContextActionService:BindToRenderStep(name, createMobileButton, ...)
+	ContextActionService:BindAction(name, createMobileButton, ...)
 	self:Add(function()
 		ContextActionService:UnbindAction(name)
 	end)

--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -214,18 +214,18 @@ end
 
 --[=[
 	@param name string
-	@param priority number
-	@param fn (dt: number) -> ()
+	@param createMobileButton boolean
+	@param fn (actionName: string, inputState: Enum.UserInputState, inputObject: InputObject) -> (Enum.ContextActionResult?)
 	Calls `CollectionService:BindAction` and registers a function in the
 	trove that will call `CollectionService:UnbindAction` on cleanup.
 
 	```lua
-	trove:BindAction("Test", Enum.RenderPriority.Last.Value, function(dt)
+	trove:BindAction("Test", true, function()
 		-- Do something
-	end)
+	end, Enum.KeyCode.E)
 	```
 ]=]
-function Trove:BindAction(name: string, createMobileButton: boolean, ...: Enum.KeyCode?)
+function Trove:BindAction(name: string, createMobileButton: boolean, fn: (actionName: string, inputState: Enum.UserInputState, inputObject: InputObject) -> (Enum.ContextActionResult?), ...: Enum.KeyCode?)
 	if self._cleaning then
 		error("Cannot call trove:BindAction() while cleaning", 2)
 	end
@@ -233,7 +233,7 @@ function Trove:BindAction(name: string, createMobileButton: boolean, ...: Enum.K
 		error("Cannot call trove:BindAction() on the server", 2)
 	end
 
-	ContextActionService:BindAction(name, createMobileButton, ...)
+	ContextActionService:BindAction(name, createMobileButton, fn, ...)
 	self:Add(function()
 		ContextActionService:UnbindAction(name)
 	end)

--- a/modules/trove/wally.toml
+++ b/modules/trove/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/trove"
 description = "Trove class for tracking and cleaning up objects"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
Updated Trove to include a variety of quality-of-life changes, including allowing the user to easily use ``signal:Once`` with the new ``Once`` method, adding ``trove:BindAction`` to allow for ContextActionService support, allowing a trove to be attached to players, characters and humanoids, and utilizing ``task.cancel`` over ``coroutine.cancel`` as to allow for the user to utilize BOTH the task and coroutine libraries.