### PR TITLE
Cleanup threads with task.cancel

### DIFF
--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -244,7 +244,7 @@ end
 	| `Instance` | `object:Destroy()` |
 	| `RBXScriptConnection` | `object:Disconnect()` |
 	| `function` | `object()` |
-	| `thread` | `coroutine.close(object)` |
+	| `thread` | `task.cancel(object)` |
 	| `table` | `object:Destroy()` _or_ `object:Disconnect()` |
 	| `table` with `cleanupMethod` | `object:<cleanupMethod>()` |
 
@@ -342,7 +342,7 @@ function Trove:_cleanupObject(object, cleanupMethod)
 	if cleanupMethod == FN_MARKER then
 		object()
 	elseif cleanupMethod == THREAD_MARKER then
-		coroutine.close(object)
+		task.cancel(object)
 	else
 		object[cleanupMethod](object)
 	end


### PR DESCRIPTION
task.cancel is preferable as it prevents an error message from appearing when the task scheduler attempts to resume a closed thread from a call to task.wait()