### PR TITLE
Trove should support more object cleanup methods

### DIFF
--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -4,8 +4,7 @@
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
-local GENERIC_OBJECT_CLEANUP_METHODS =
-	{ "Destroy", "Disconnect", "Cleanup", "destroy", "disconnect", "cleanup" }
+local GENERIC_OBJECT_CLEANUP_METHODS = { "Destroy", "Disconnect", "Cleanup", "destroy", "disconnect", "cleanup" }
 
 local RunService = game:GetService("RunService")
 
@@ -24,9 +23,9 @@ local function GetObjectCleanupFunction(object, cleanupMethod)
 	elseif t == "RBXScriptConnection" then
 		return "Disconnect"
 	elseif t == "table" then
-		for _, cleanupMethod in GENERIC_OBJECT_CLEANUP_METHODS do
-			if typeof(object[cleanupMethod]) == "function" then
-				return cleanupMethod
+		for _, genericCleanupMethod in GENERIC_OBJECT_CLEANUP_METHODS do
+			if typeof(object[genericCleanupMethod]) == "function" then
+				return genericCleanupMethod
 			end
 		end
 	end

--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -5,7 +5,7 @@
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
 local GENERIC_OBJECT_CLEANUP_METHODS =
-	{ "Destroy", "Disconnect", "Cleanup", "Deinit", "Clean", "destroy", "disconnect", "cleanup", "deinit", "clean" }
+	{ "Destroy", "Disconnect", "destroy", "disconnect" }
 
 local RunService = game:GetService("RunService")
 

--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -4,7 +4,8 @@
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
-local GENERIC_OBJECT_CLEANUP_METHODS = { "Destroy", "Disconnect", "Cleanup", "Deinit", "Clean", "destroy", "disconnect", "cleanup", "deinit", "clean" }
+local GENERIC_OBJECT_CLEANUP_METHODS =
+	{ "Destroy", "Disconnect", "Cleanup", "Deinit", "Clean", "destroy", "disconnect", "cleanup", "deinit", "clean" }
 
 local RunService = game:GetService("RunService")
 

--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -4,7 +4,7 @@
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
-local GENERIC_OBJECT_CLEANUP_METHODS = { "Destroy", "Disconnect", "Cleanup", "destroy", "disconnect", "cleanup" }
+local GENERIC_OBJECT_CLEANUP_METHODS = { "Destroy", "Disconnect", "Cleanup", "Deinit", "Clean", "destroy", "disconnect", "cleanup", "deinit", "clean" }
 
 local RunService = game:GetService("RunService")
 

--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -4,7 +4,8 @@
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
-local GENERIC_OBJECT_CLEANUP_METHODS = {"Destroy", "Disconnect", "Cleanup", "destroy", "disconnect", "cleanup"}
+local GENERIC_OBJECT_CLEANUP_METHODS =
+	{ "Destroy", "Disconnect", "Cleanup", "destroy", "disconnect", "cleanup" }
 
 local RunService = game:GetService("RunService")
 
@@ -24,7 +25,9 @@ local function GetObjectCleanupFunction(object, cleanupMethod)
 		return "Disconnect"
 	elseif t == "table" then
 		for _, cleanupMethod in GENERIC_OBJECT_CLEANUP_METHODS do
-			if typeof(object[cleanupMethod]) == "function" then return cleanupMethod end
+			if typeof(object[cleanupMethod]) == "function" then
+				return cleanupMethod
+			end
 		end
 	end
 	error("Failed to get cleanup function for object " .. t .. ": " .. tostring(object), 3)

--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -4,8 +4,7 @@
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
-local GENERIC_OBJECT_CLEANUP_METHODS =
-	{ "Destroy", "Disconnect", "destroy", "disconnect" }
+local GENERIC_OBJECT_CLEANUP_METHODS = { "Destroy", "Disconnect", "destroy", "disconnect" }
 
 local RunService = game:GetService("RunService")
 

--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -4,6 +4,7 @@
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
+local GENERIC_OBJECT_CLEANUP_METHODS = {"Destroy", "Disconnect", "Cleanup", "destroy", "disconnect", "cleanup"}
 
 local RunService = game:GetService("RunService")
 
@@ -22,10 +23,8 @@ local function GetObjectCleanupFunction(object, cleanupMethod)
 	elseif t == "RBXScriptConnection" then
 		return "Disconnect"
 	elseif t == "table" then
-		if typeof(object.Destroy) == "function" then
-			return "Destroy"
-		elseif typeof(object.Disconnect) == "function" then
-			return "Disconnect"
+		for _, cleanupMethod in GENERIC_OBJECT_CLEANUP_METHODS do
+			if typeof(object[cleanupMethod]) == "function" then return cleanupMethod end
 		end
 	end
 	error("Failed to get cleanup function for object " .. t .. ": " .. tostring(object), 3)


### PR DESCRIPTION
Right now, Trove only supports `Destroy` and `Disconnect` as object cleanup methods. Cleanup methods other than these 2 have to be specified through `Trove:Add`.

However, Trove *should* also support camel case versions of these cleanup methods, as developers tend to follow various style guides when writing code. However, the [Roblox Lua Style Guide](https://roblox.github.io/lua-style-guide/) generally states that methods should be generally `camelCase`.

For those who follow this (widely-used) style guide, it is inconvenient for them to specify the cleanup method through `Trove:Add`..

 This PR makes Trove support the following **additional* generic object cleanup methods:
- `destroy`
- `disconnect`