### PR TITLE
Protected call on task.cancel

### DIFF
--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -342,7 +342,7 @@ function Trove:_cleanupObject(object, cleanupMethod)
 	if cleanupMethod == FN_MARKER then
 		object()
 	elseif cleanupMethod == THREAD_MARKER then
-		task.cancel(object)
+		pcall(task.cancel, object)
 	else
 		object[cleanupMethod](object)
 	end


### PR DESCRIPTION
task.cancel often errors if the provided thread is not in the correct state, add pcall to protect against an error during cleanup.

Roblox task library API reference states "code should not rely on specific thread states or conditions causing task.cancel() to fail. It is possible that future updates will eliminate these constraints and allow threads in these states to be successfully cancelled."