### PR TITLE
Added support for sub folders containing events.

### DIFF
--- a/modules/comm/Client/init.lua
+++ b/modules/comm/Client/init.lua
@@ -11,10 +11,11 @@ function Client.GetFunction(
 	name: string,
 	usePromise: boolean,
 	inboundMiddleware: Types.ClientMiddleware?,
-	outboundMiddleware: Types.ClientMiddleware?
+	outboundMiddleware: Types.ClientMiddleware?,
+	subFolders: { string }?
 )
 	assert(not Util.IsServer, "GetFunction must be called from the client")
-	local folder = Util.GetCommSubFolder(parent, "RF"):Expect("Failed to get Comm RF folder")
+	local folder = Util.GetCommSubFolder(parent, "RF", subFolders):Expect("Failed to get Comm RF folder")
 	local rf = folder:WaitForChild(name, Util.WaitForChildTimeout)
 	assert(rf ~= nil, "Failed to find RemoteFunction: " .. name)
 	local hasInbound = type(inboundMiddleware) == "table" and #inboundMiddleware > 0
@@ -110,10 +111,11 @@ function Client.GetSignal(
 	parent: Instance,
 	name: string,
 	inboundMiddleware: Types.ClientMiddleware?,
-	outboundMiddleware: Types.ClientMiddleware?
+	outboundMiddleware: Types.ClientMiddleware?,
+	subFolders: { string }?
 )
 	assert(not Util.IsServer, "GetSignal must be called from the client")
-	local folder = Util.GetCommSubFolder(parent, "RE"):Expect("Failed to get Comm RE folder")
+	local folder = Util.GetCommSubFolder(parent, "RE", subFolders):Expect("Failed to get Comm RE folder")
 	local re = folder:WaitForChild(name, Util.WaitForChildTimeout)
 	assert(re ~= nil, "Failed to find RemoteEvent: " .. name)
 	return ClientRemoteSignal.new(re, inboundMiddleware, outboundMiddleware)
@@ -123,10 +125,11 @@ function Client.GetProperty(
 	parent: Instance,
 	name: string,
 	inboundMiddleware: Types.ClientMiddleware?,
-	outboundMiddleware: Types.ClientMiddleware?
+	outboundMiddleware: Types.ClientMiddleware?,
+	subFolders: { string }?
 )
 	assert(not Util.IsServer, "GetProperty must be called from the client")
-	local folder = Util.GetCommSubFolder(parent, "RP"):Expect("Failed to get Comm RP folder")
+	local folder = Util.GetCommSubFolder(parent, "RP", subFolders):Expect("Failed to get Comm RP folder")
 	local re = folder:WaitForChild(name, Util.WaitForChildTimeout)
 	assert(re ~= nil, "Failed to find RemoteEvent for RemoteProperty: " .. name)
 	return ClientRemoteProperty.new(re, inboundMiddleware, outboundMiddleware)

--- a/modules/comm/Server/ServerComm.lua
+++ b/modules/comm/Server/ServerComm.lua
@@ -77,9 +77,10 @@ function ServerComm:BindFunction(
 	name: string,
 	fn: Types.FnBind,
 	inboundMiddleware: Types.ServerMiddleware?,
-	outboundMiddleware: Types.ServerMiddleware?
+	outboundMiddleware: Types.ServerMiddleware?,
+	subFolders: { string }?
 ): RemoteFunction
-	return Comm.BindFunction(self._instancesFolder, name, fn, inboundMiddleware, outboundMiddleware)
+	return Comm.BindFunction(self._instancesFolder, name, fn, inboundMiddleware, outboundMiddleware, subFolders)
 end
 
 --[=[
@@ -109,9 +110,10 @@ function ServerComm:WrapMethod(
 	tbl: {},
 	name: string,
 	inboundMiddleware: Types.ServerMiddleware?,
-	outboundMiddleware: Types.ServerMiddleware?
+	outboundMiddleware: Types.ServerMiddleware?,
+	subFolders: { string }?
 ): RemoteFunction
-	return Comm.WrapMethod(self._instancesFolder, tbl, name, inboundMiddleware, outboundMiddleware)
+	return Comm.WrapMethod(self._instancesFolder, tbl, name, inboundMiddleware, outboundMiddleware, subFolders)
 end
 
 --[=[
@@ -141,9 +143,10 @@ end
 function ServerComm:CreateSignal(
 	name: string,
 	inboundMiddleware: Types.ServerMiddleware?,
-	outboundMiddleware: Types.ServerMiddleware?
+	outboundMiddleware: Types.ServerMiddleware?,
+	subFolders: { string }?
 )
-	return Comm.CreateSignal(self._instancesFolder, name, inboundMiddleware, outboundMiddleware)
+	return Comm.CreateSignal(self._instancesFolder, name, inboundMiddleware, outboundMiddleware, subFolders)
 end
 
 --[=[
@@ -190,9 +193,17 @@ function ServerComm:CreateProperty(
 	name: string,
 	initialValue: any,
 	inboundMiddleware: Types.ServerMiddleware?,
-	outboundMiddleware: Types.ServerMiddleware?
+	outboundMiddleware: Types.ServerMiddleware?,
+	subFolders: { string }?
 )
-	return Comm.CreateProperty(self._instancesFolder, name, initialValue, inboundMiddleware, outboundMiddleware)
+	return Comm.CreateProperty(
+		self._instancesFolder,
+		name,
+		initialValue,
+		inboundMiddleware,
+		outboundMiddleware,
+		subFolders
+	)
 end
 
 --[=[

--- a/modules/comm/Server/init.lua
+++ b/modules/comm/Server/init.lua
@@ -39,10 +39,11 @@ function Server.BindFunction(
 	name: string,
 	func: Types.FnBind,
 	inboundMiddleware: Types.ServerMiddleware?,
-	outboundMiddleware: Types.ServerMiddleware?
+	outboundMiddleware: Types.ServerMiddleware?,
+	subFolders: { string }?
 ): RemoteFunction
 	assert(Util.IsServer, "BindFunction must be called from the server")
-	local folder = Util.GetCommSubFolder(parent, "RF"):Expect("Failed to get Comm RF folder")
+	local folder = Util.GetCommSubFolder(parent, "RF", subFolders):Expect("Failed to get Comm RF folder")
 	local rf = Instance.new("RemoteFunction")
 	rf.Name = name
 	local hasInbound = type(inboundMiddleware) == "table" and #inboundMiddleware > 0
@@ -101,24 +102,26 @@ function Server.WrapMethod(
 	tbl: {},
 	name: string,
 	inboundMiddleware: Types.ServerMiddleware?,
-	outboundMiddleware: Types.ServerMiddleware?
+	outboundMiddleware: Types.ServerMiddleware?,
+	subFolders: { string }?
 ): RemoteFunction
 	assert(Util.IsServer, "WrapMethod must be called from the server")
 	local fn = tbl[name]
 	assert(type(fn) == "function", "Value at index " .. name .. " must be a function; got " .. type(fn))
 	return Server.BindFunction(parent, name, function(...)
 		return fn(tbl, ...)
-	end, inboundMiddleware, outboundMiddleware)
+	end, inboundMiddleware, outboundMiddleware, subFolders)
 end
 
 function Server.CreateSignal(
 	parent: Instance,
 	name: string,
 	inboundMiddleware: Types.ServerMiddleware?,
-	outboundMiddleware: Types.ServerMiddleware?
+	outboundMiddleware: Types.ServerMiddleware?,
+	subFolders: { string }?
 )
 	assert(Util.IsServer, "CreateSignal must be called from the server")
-	local folder = Util.GetCommSubFolder(parent, "RE"):Expect("Failed to get Comm RE folder")
+	local folder = Util.GetCommSubFolder(parent, "RE", subFolders):Expect("Failed to get Comm RE folder")
 	local rs = RemoteSignal.new(folder, name, inboundMiddleware, outboundMiddleware)
 	return rs
 end
@@ -128,10 +131,11 @@ function Server.CreateProperty(
 	name: string,
 	initialValue: any,
 	inboundMiddleware: Types.ServerMiddleware?,
-	outboundMiddleware: Types.ServerMiddleware?
+	outboundMiddleware: Types.ServerMiddleware?,
+	subFolders: { string }?
 )
 	assert(Util.IsServer, "CreateProperty must be called from the server")
-	local folder = Util.GetCommSubFolder(parent, "RP"):Expect("Failed to get Comm RP folder")
+	local folder = Util.GetCommSubFolder(parent, "RP", subFolders):Expect("Failed to get Comm RP folder")
 	local rp = RemoteProperty.new(folder, name, initialValue, inboundMiddleware, outboundMiddleware)
 	return rp
 end

--- a/modules/comm/Util.lua
+++ b/modules/comm/Util.lua
@@ -34,7 +34,6 @@ function Util.GetCommSubFolder(parent: Instance, subFolderName: string, subFolde
 		subFolder = parent:WaitForChild(subFolderName, Util.WaitForChildTimeout)
 
 		if subFolders then
-			local parent
 			for _, t in subFolders do
 				subFolder = subFolder:WaitForChild(t, Util.WaitForChildTimeout)
 			end

--- a/modules/comm/Util.lua
+++ b/modules/comm/Util.lua
@@ -9,7 +9,7 @@ Util.WaitForChildTimeout = 60
 Util.DefaultCommFolderName = "__comm__"
 Util.None = newproxy()
 
-function Util.GetCommSubFolder(parent: Instance, subFolderName: string): Option.Option
+function Util.GetCommSubFolder(parent: Instance, subFolderName: string, subFolders: { string }?): Option.Option
 	local subFolder: Instance = nil
 	if Util.IsServer then
 		subFolder = parent:FindFirstChild(subFolderName)
@@ -18,8 +18,27 @@ function Util.GetCommSubFolder(parent: Instance, subFolderName: string): Option.
 			subFolder.Name = subFolderName
 			subFolder.Parent = parent
 		end
+
+		if subFolders then
+			for _, t in subFolders do
+				parent = subFolder
+				subFolder = parent:FindFirstChild(t)
+				if not subFolder then
+					subFolder = Instance.new("Folder")
+					subFolder.Name = t
+					subFolder.Parent = parent
+				end
+			end
+		end
 	else
 		subFolder = parent:WaitForChild(subFolderName, Util.WaitForChildTimeout)
+
+		if subFolders then
+			local parent
+			for _, t in subFolders do
+				subFolder = subFolder:WaitForChild(t, Util.WaitForChildTimeout)
+			end
+		end
 	end
 	return Option.Wrap(subFolder)
 end


### PR DESCRIPTION
This is an issue related to using Knit and there is another [Pull Request](https://github.com/Sleitnick/Knit/pull/233).

Within Knit, you cannot have any tables containing RemoteEvents, RemoteProperties or Methods within the `service.Client` table.

For example, the following code will generate a remote event for PlayerAdded, but **will not** generate one for Update:
```lua
Knit.CreateService({
	Name = "ExampleService",
	
	Client = {
		PlayerAdded = Knit.CreateSignal(),
		
		Data = {
			Update = Knit.CreateSignal(),
		},		
	}
})
```

This issue cannot be fixed within Knit on its own, but requires changing around the structure of Comm slightly. This update only adds, and is entirely optional in new features. There shouldn't be any changes to existing code.

The change involves adding a new optional subFolder argument which is a string array of subfolder names to create. Within Util, rather than looking just for the correct folder at the top, the subFolder argument will create any additional folders underneath each RemoteProperty, RemoteFunction and RemoteEvent folder to reflect the table structure.

The new service tree hierarchy can look like this with subfolders:
```
ExampleService (Folder)
└── RE (Folder)
    ├── Data (Folder)
    │   └── Update (RE)
    └── PlayerAdded (RE)
```

ClientComm has also been updated to check if a folder contains any other folders and perform a recursive search on those to fully traverse the service tree.