### PR TITLE
(Fix) ClientRemoteProperty doesn't update in edge case

### DIFF
--- a/modules/comm/Client/ClientRemoteProperty.lua
+++ b/modules/comm/Client/ClientRemoteProperty.lua
@@ -137,7 +137,9 @@ end
 ]=]
 function ClientRemoteProperty:Observe(observer: (any) -> ())
 	if self._ready then
-		task.defer(observer, self._value)
+		task.defer(function()
+			observer(self._value)
+		end)
 	end
 	return self.Changed:Connect(observer)
 end


### PR DESCRIPTION
See: #155 

This PR offers a fix for an issue where ClientRemoteProperty can initialize with the wrong value, and ignore updates to a remote property from the server that happen before a player's client loads.