### PR TITLE
(Fix) ClientRemoteProperty doesn't update in edge case

### DIFF
--- a/modules/comm/Client/ClientRemoteProperty.lua
+++ b/modules/comm/Client/ClientRemoteProperty.lua
@@ -36,10 +36,8 @@ function ClientRemoteProperty.new(
 )
 	local self = setmetatable({}, ClientRemoteProperty)
 	self._rs = ClientRemoteSignal.new(re, inboundMiddleware, outboudMiddleware)
-
 	self._ready = false
 	self._value = nil
-
 	self.Changed = Signal.new()
 	self._rs:Fire()
 

--- a/modules/comm/Client/ClientRemoteProperty.lua
+++ b/modules/comm/Client/ClientRemoteProperty.lua
@@ -133,7 +133,9 @@ end
 ]=]
 function ClientRemoteProperty:Observe(observer: (any) -> ())
 	if self._ready then
-		task.defer(observer, self._value)
+		task.defer(function()
+			observer(self._value)
+		end)
 	end
 	return self.Changed:Connect(observer)
 end


### PR DESCRIPTION
See: https://github.com/Sleitnick/RbxUtil/issues/155

This PR offers a fix for an issue where ClientRemoteProperty can initialize with the wrong value, and ignore updates to a remote property from the server that happen before a player's client loads.

This also fixes a race condition where calling ClientRemoteProperty:Observe() on KnitStart can cause value updates to be processed out of order.