### PR TITLE
Cancel waiting threads if signal disconnects all connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,26 @@
 
 | Module | Dependency | Description |
 | -- | -- | -- |
-| [Tree](https://sleitnick.github.io/RbxUtil/api/Tree) | `Tree = "sleitnick/tree@1.1.0"` | Utility functions for accessing instances in the game hierarchy |
-| [Silo](https://sleitnick.github.io/RbxUtil/api/Silo) | `Silo = "sleitnick/silo@0.1.1"` | State container class |
-| [TableUtil](https://sleitnick.github.io/RbxUtil/api/TableUtil) | `TableUtil = "sleitnick/table-util@1.2.0"` | Table utility functions |
-| [Net](https://sleitnick.github.io/RbxUtil/api/Net) | `Net = "sleitnick/net@0.1.0"` | Static networking module |
-| [Streamable](https://sleitnick.github.io/RbxUtil/api/Streamable) | `Streamable = "sleitnick/streamable@1.2.4"` | Streamable class and StreamableUtil |
-| [TaskQueue](https://sleitnick.github.io/RbxUtil/api/TaskQueue) | `TaskQueue = "sleitnick/task-queue@1.0.0"` | Batches tasks that occur on the same execution step |
-| [Shake](https://sleitnick.github.io/RbxUtil/api/Shake) | `Shake = "sleitnick/shake@0.1.7"` | Shake class for making things shake |
-| [Input](https://sleitnick.github.io/RbxUtil/api/Input) | `Input = "sleitnick/input@2.2.0"` | Basic input classes |
-| [Timer](https://sleitnick.github.io/RbxUtil/api/Timer) | `Timer = "sleitnick/timer@1.1.2"` | Timer class |
-| [Trove](https://sleitnick.github.io/RbxUtil/api/Trove) | `Trove = "sleitnick/trove@1.0.1"` | Trove class for tracking and cleaning up objects |
 | [Comm](https://sleitnick.github.io/RbxUtil/api/Comm) | `Comm = "sleitnick/comm@0.3.2"` | Comm library for remote communication |
 | [Component](https://sleitnick.github.io/RbxUtil/api/Component) | `Component = "sleitnick/component@2.4.6"` | Component class |
-| [Symbol](https://sleitnick.github.io/RbxUtil/api/Symbol) | `Symbol = "sleitnick/symbol@2.0.1"` | Symbol |
-| [Option](https://sleitnick.github.io/RbxUtil/api/Option) | `Option = "sleitnick/option@1.0.4"` | Represent optional values in Lua |
-| [EnumList](https://sleitnick.github.io/RbxUtil/api/EnumList) | `EnumList = "sleitnick/enum-list@2.1.0"` | Enum List class |
-| [PID](https://sleitnick.github.io/RbxUtil/api/PID) | `PID = "sleitnick/pid@1.1.0"` | PID Controller class |
-| [Loader](https://sleitnick.github.io/RbxUtil/api/Loader) | `Loader = "sleitnick/loader@2.0.0"` | Requires all modules within a given instance |
 | [Concur](https://sleitnick.github.io/RbxUtil/api/Concur) | `Concur = "sleitnick/concur@0.1.2"` | Concurrent task handler |
+| [EnumList](https://sleitnick.github.io/RbxUtil/api/EnumList) | `EnumList = "sleitnick/enum-list@2.1.0"` | Enum List class |
+| [Input](https://sleitnick.github.io/RbxUtil/api/Input) | `Input = "sleitnick/input@2.2.0"` | Basic input classes |
+| [Loader](https://sleitnick.github.io/RbxUtil/api/Loader) | `Loader = "sleitnick/loader@2.0.0"` | Requires all modules within a given instance |
 | [Log](https://sleitnick.github.io/RbxUtil/api/Log) | `Log = "sleitnick/log@0.1.1"` | Log class for logging to PlayFab |
+| [Net](https://sleitnick.github.io/RbxUtil/api/Net) | `Net = "sleitnick/net@0.1.0"` | Static networking module |
+| [Option](https://sleitnick.github.io/RbxUtil/api/Option) | `Option = "sleitnick/option@1.0.4"` | Represent optional values in Lua |
+| [PID](https://sleitnick.github.io/RbxUtil/api/PID) | `PID = "sleitnick/pid@1.1.0"` | PID Controller class |
 | [Quaternion](https://sleitnick.github.io/RbxUtil/api/Quaternion) | `Quaternion = "sleitnick/quaternion@0.2.3"` | Quaternion class |
 | [Ser](https://sleitnick.github.io/RbxUtil/api/Ser) | `Ser = "sleitnick/ser@1.0.5"` | Ser class for serialization and deserialization |
+| [Shake](https://sleitnick.github.io/RbxUtil/api/Shake) | `Shake = "sleitnick/shake@0.1.7"` | Shake class for making things shake |
+| [Signal](https://sleitnick.github.io/RbxUtil/api/Signal) | `Signal = "sleitnick/signal@2.0.0"` | Signal class |
+| [Silo](https://sleitnick.github.io/RbxUtil/api/Silo) | `Silo = "sleitnick/silo@0.1.1"` | State container class |
+| [Streamable](https://sleitnick.github.io/RbxUtil/api/Streamable) | `Streamable = "sleitnick/streamable@1.2.4"` | Streamable class and StreamableUtil |
+| [Symbol](https://sleitnick.github.io/RbxUtil/api/Symbol) | `Symbol = "sleitnick/symbol@2.0.1"` | Symbol |
+| [TableUtil](https://sleitnick.github.io/RbxUtil/api/TableUtil) | `TableUtil = "sleitnick/table-util@1.2.0"` | Table utility functions |
+| [TaskQueue](https://sleitnick.github.io/RbxUtil/api/TaskQueue) | `TaskQueue = "sleitnick/task-queue@1.0.0"` | Batches tasks that occur on the same execution step |
+| [Timer](https://sleitnick.github.io/RbxUtil/api/Timer) | `Timer = "sleitnick/timer@1.1.2"` | Timer class |
+| [Tree](https://sleitnick.github.io/RbxUtil/api/Tree) | `Tree = "sleitnick/tree@1.1.0"` | Utility functions for accessing instances in the game hierarchy |
+| [Trove](https://sleitnick.github.io/RbxUtil/api/Trove) | `Trove = "sleitnick/trove@1.0.1"` | Trove class for tracking and cleaning up objects |
 | [WaitFor](https://sleitnick.github.io/RbxUtil/api/WaitFor) | `WaitFor = "sleitnick/wait-for@1.0.0"` | WaitFor class for awaiting instances |
-| [Signal](https://sleitnick.github.io/RbxUtil/api/Signal) | `Signal = "sleitnick/signal@1.5.0"` | Signal class |

--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -294,7 +294,7 @@ function Signal:DisconnectAll()
 	if self._yieldedThreads then
 		for thread in self._yieldedThreads do
 			if coroutine.status(thread) == "suspended" then
-				warn(debug.traceback(thread, "signal destroyed; yielded thread is being cancelled"))
+				warn(debug.traceback(thread, "signal destroyed; yielded thread is being cancelled", 2))
 				task.cancel(thread)
 			end
 		end

--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -294,7 +294,7 @@ function Signal:DisconnectAll()
 	if self._yieldedThreads then
 		for thread in self._yieldedThreads do
 			if coroutine.status(thread) == "suspended" then
-				warn(debug.traceback(thread, "signal destroyed; yielded thread is being cancelled", 2))
+				warn(debug.traceback(thread, "signal disconnected; yielded thread is being cancelled", 2))
 				task.cancel(thread)
 			end
 		end

--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -7,15 +7,6 @@
 -- the signal handlers comes at minimal extra cost over a naive signal        --
 -- implementation that either always or never spawns a thread.                --
 --                                                                            --
--- API:                                                                       --
---   local Signal = require(THIS MODULE)                                      --
---   local sig = Signal.new()                                                 --
---   local connection = sig:Connect(function(arg1, arg2, ...) ... end)        --
---   sig:Fire(arg1, arg2, ...)                                                --
---   connection:Disconnect()                                                  --
---   sig:DisconnectAll()                                                      --
---   local arg1, arg2, ... = sig:Wait()                                       --
---                                                                            --
 -- License:                                                                   --
 --   Licensed under the MIT license.                                          --
 --                                                                            --
@@ -87,15 +78,6 @@ end
 local Connection = {}
 Connection.__index = Connection
 
-function Connection.new(signal, fn)
-	return setmetatable({
-		Connected = true,
-		_signal = signal,
-		_fn = fn,
-		_next = false,
-	}, Connection)
-end
-
 function Connection:Disconnect()
 	if not self.Connected then
 		return
@@ -166,7 +148,9 @@ function Signal.new<T...>(): Signal<T...>
 	local self = setmetatable({
 		_handlerListHead = false,
 		_proxyHandler = nil,
+		_yieldedThreads = nil,
 	}, Signal)
+
 	return self
 end
 
@@ -188,10 +172,12 @@ function Signal.Wrap<T...>(rbxScriptSignal: RBXScriptSignal): Signal<T...>
 		typeof(rbxScriptSignal) == "RBXScriptSignal",
 		"Argument #1 to Signal.Wrap must be a RBXScriptSignal; got " .. typeof(rbxScriptSignal)
 	)
+
 	local signal = Signal.new()
 	signal._proxyHandler = rbxScriptSignal:Connect(function(...)
 		signal:Fire(...)
 	end)
+
 	return signal
 end
 
@@ -219,13 +205,20 @@ end
 	```
 ]=]
 function Signal:Connect(fn)
-	local connection = Connection.new(self, fn)
+	local connection = setmetatable({
+		Connected = true,
+		_signal = self,
+		_fn = fn,
+		_next = false,
+	}, Connection)
+
 	if self._handlerListHead then
 		connection._next = self._handlerListHead
 		self._handlerListHead = connection
 	else
 		self._handlerListHead = connection
 	end
+
 	return connection
 end
 
@@ -256,24 +249,29 @@ end
 function Signal:Once(fn)
 	local connection
 	local done = false
+
 	connection = self:Connect(function(...)
 		if done then
 			return
 		end
+
 		done = true
 		connection:Disconnect()
 		fn(...)
 	end)
+
 	return connection
 end
 
 function Signal:GetConnections()
 	local items = {}
+
 	local item = self._handlerListHead
 	while item do
 		table.insert(items, item)
 		item = item._next
 	end
+
 	return items
 end
 
@@ -292,6 +290,15 @@ function Signal:DisconnectAll()
 		item = item._next
 	end
 	self._handlerListHead = false
+
+	if self._yieldedThreads then
+		for thread in self._yieldedThreads do
+			if coroutine.status(thread) == "suspended" then
+				task.cancel(thread)
+			end
+		end
+		table.clear(self._yieldedThreads)
+	end
 end
 
 -- Signal:Fire(...) implemented by running the handler functions on the
@@ -333,7 +340,9 @@ end
 function Signal:FireDeferred(...)
 	local item = self._handlerListHead
 	while item do
-		task.defer(item._fn, ...)
+		if item.Connected then
+			task.defer(item._fn, ...)
+		end
 		item = item._next
 	end
 end
@@ -354,17 +363,20 @@ end
 	```
 ]=]
 function Signal:Wait()
-	local waitingCoroutine = coroutine.running()
-	local connection
-	local done = false
-	connection = self:Connect(function(...)
-		if done then
-			return
-		end
-		done = true
-		connection:Disconnect()
-		task.spawn(waitingCoroutine, ...)
+	local yieldedThreads = rawget(self, "_yieldedThreads")
+	if not yieldedThreads then
+		yieldedThreads = {}
+		rawset(self, "_yieldedThreads", yieldedThreads)
+	end
+
+	local thread = coroutine.running()
+	yieldedThreads[thread] = true
+
+	self:Once(function(...)
+		yieldedThreads[thread] = nil
+		task.spawn(thread, ...)
 	end)
+
 	return coroutine.yield()
 end
 
@@ -382,6 +394,7 @@ end
 ]=]
 function Signal:Destroy()
 	self:DisconnectAll()
+
 	local proxyHandler = rawget(self, "_proxyHandler")
 	if proxyHandler then
 		proxyHandler:Disconnect()
@@ -398,8 +411,8 @@ setmetatable(Signal, {
 	end,
 })
 
-return {
+return table.freeze({
 	new = Signal.new,
 	Wrap = Signal.Wrap,
 	Is = Signal.Is,
-}
+})

--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -340,9 +340,10 @@ end
 function Signal:FireDeferred(...)
 	local item = self._handlerListHead
 	while item do
+		local conn = item
 		task.defer(function(...)
-			if item.Connected then
-				item._fn(...)
+			if conn.Connected then
+				conn._fn(...)
 			end
 		end, ...)
 		item = item._next

--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -294,6 +294,7 @@ function Signal:DisconnectAll()
 	if self._yieldedThreads then
 		for thread in self._yieldedThreads do
 			if coroutine.status(thread) == "suspended" then
+				warn(debug.traceback(thread, "signal destroyed; yielded thread is being cancelled"))
 				task.cancel(thread)
 			end
 		end

--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -340,9 +340,11 @@ end
 function Signal:FireDeferred(...)
 	local item = self._handlerListHead
 	while item do
-		if item.Connected then
-			task.defer(item._fn, ...)
-		end
+		task.defer(function(...)
+			if item.Connected then
+				item._fn(...)
+			end
+		end, ...)
 		item = item._next
 	end
 end

--- a/modules/signal/wally.toml
+++ b/modules/signal/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/signal"
 description = "Signal class"
-version = "1.5.0"
+version = "2.0.0"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
Closes #163

This also fixes a potential for `FireDeferred` to invoke disconnected handlers in scenarios in which a handler disconnects another handler.