### PR TITLE
Signal:Wait() regulation

### DIFF
--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -355,14 +355,7 @@ end
 ]=]
 function Signal:Wait()
 	local waitingCoroutine = coroutine.running()
-	local connection
-	local done = false
-	connection = self:Connect(function(...)
-		if done then
-			return
-		end
-		done = true
-		connection:Disconnect()
+	self:Once(function(...)
 		task.spawn(waitingCoroutine, ...)
 	end)
 	return coroutine.yield()


### PR DESCRIPTION
```lua
local waitingCoroutine = coroutine.running()
local connection
local done = false
connection = self:Connect(function(...)
	if done then
		return
	end
	done = true
	connection:Disconnect()
	task.spawn(waitingCoroutine, ...)
end)
return coroutine.yield()
```

I think it is a shorter way to use `Signal:Once(fn)`, which serves the same function as this code and is available in Signal.

```lua
local waitingCoroutine = coroutine.running()
self:Once(function(...)
	task.spawn(waitingCoroutine, ...)
end)
return coroutine.yield()
```

They can perform the same function, but it would be better to use the function found in Signal methods.