### PR TITLE
Fix Signal bug when Destroying

### DIFF
--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -291,8 +291,9 @@ function Signal:DisconnectAll()
 	end
 	self._handlerListHead = false
 
-	if rawget(self, "_yieldedThreads") then
-		for thread in rawget(self, "_yieldedThreads") do
+	local yieldedThreads = rawget(self, "_yieldedThreads")
+	if yieldedThreads then
+		for thread in yieldedThreads do
 			if coroutine.status(thread) == "suspended" then
 				warn(debug.traceback(thread, "signal disconnected; yielded thread cancelled", 2))
 				task.cancel(thread)

--- a/modules/signal/init.lua
+++ b/modules/signal/init.lua
@@ -291,8 +291,8 @@ function Signal:DisconnectAll()
 	end
 	self._handlerListHead = false
 
-	if self._yieldedThreads then
-		for thread in self._yieldedThreads do
+	if rawget(self, "_yieldedThreads") then
+		for thread in rawget(self, "_yieldedThreads") do
 			if coroutine.status(thread) == "suspended" then
 				warn(debug.traceback(thread, "signal disconnected; yielded thread cancelled", 2))
 				task.cancel(thread)


### PR DESCRIPTION
Everytime you tried to destroy an Signal. It would throw an error saying "Attempt to get Signal:__yieldedThreads (not a valid member)"

Switched to using rawget for __yieldedThreads