### PR TITLE
Allow for variable arguments to be passed to the method in Loader.SpawnAll

### DIFF
--- a/modules/loader/init.lua
+++ b/modules/loader/init.lua
@@ -122,13 +122,13 @@ end
 	)
 	```
 ]=]
-function Loader.SpawnAll(loadedModules: { [string]: any }, methodName: string)
+function Loader.SpawnAll(loadedModules: { [string]: any }, methodName: string, ...)
 	for name, mod in loadedModules do
 		local method = mod[methodName]
 		if type(method) == "function" then
 			task.spawn(function()
 				debug.setmemorycategory(name)
-				method(mod)
+				method(mod, ...)
 			end)
 		end
 	end


### PR DESCRIPTION
It is a common use case to pass arguments into functions that are called using the `Loader.SpawnAll` function, but it is impossible to do this with the function in its current state. I changed the function to take in a variable number of arguments `...` that is passed directly into the function that gets called.