### PR TITLE
Corrected PID calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [Log](https://sleitnick.github.io/RbxUtil/api/Log) | `Log = "sleitnick/log@0.1.1"` | Log class for logging to PlayFab |
 | [Net](https://sleitnick.github.io/RbxUtil/api/Net) | `Net = "sleitnick/net@0.2.0"` | Static networking module |
 | [Option](https://sleitnick.github.io/RbxUtil/api/Option) | `Option = "sleitnick/option@1.0.5"` | Represent optional values in Lua |
-| [PID](https://sleitnick.github.io/RbxUtil/api/PID) | `PID = "sleitnick/pid@1.2.1"` | PID Controller class |
+| [PID](https://sleitnick.github.io/RbxUtil/api/PID) | `PID = "sleitnick/pid@1.2.2"` | PID Controller class |
 | [Quaternion](https://sleitnick.github.io/RbxUtil/api/Quaternion) | `Quaternion = "sleitnick/quaternion@0.2.3"` | Quaternion class |
 | [Sequent](https://sleitnick.github.io/RbxUtil/api/Sequent) | `Sequent = "sleitnick/sequent@0.1.0"` | Sequent class |
 | [Ser](https://sleitnick.github.io/RbxUtil/api/Ser) | `Ser = "sleitnick/ser@1.0.5"` | Ser class for serialization and deserialization |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [Log](https://sleitnick.github.io/RbxUtil/api/Log) | `Log = "sleitnick/log@0.1.1"` | Log class for logging to PlayFab |
 | [Net](https://sleitnick.github.io/RbxUtil/api/Net) | `Net = "sleitnick/net@0.2.0"` | Static networking module |
 | [Option](https://sleitnick.github.io/RbxUtil/api/Option) | `Option = "sleitnick/option@1.0.5"` | Represent optional values in Lua |
-| [PID](https://sleitnick.github.io/RbxUtil/api/PID) | `PID = "sleitnick/pid@1.2.2"` | PID Controller class |
+| [PID](https://sleitnick.github.io/RbxUtil/api/PID) | `PID = "sleitnick/pid@2.0.0"` | PID Controller class |
 | [Quaternion](https://sleitnick.github.io/RbxUtil/api/Quaternion) | `Quaternion = "sleitnick/quaternion@0.2.3"` | Quaternion class |
 | [Sequent](https://sleitnick.github.io/RbxUtil/api/Sequent) | `Sequent = "sleitnick/sequent@0.1.0"` | Sequent class |
 | [Ser](https://sleitnick.github.io/RbxUtil/api/Ser) | `Ser = "sleitnick/ser@1.0.5"` | Ser class for serialization and deserialization |

--- a/modules/pid/index.d.ts
+++ b/modules/pid/index.d.ts
@@ -15,27 +15,14 @@ declare namespace PID {
 
 interface PID {
 	/**
-	 * POnE stands for "Proportional on Error".
-	 *
-	 * Set to `true` by default.
-	 *
-	 * - `true`: The PID applies the proportional calculation on the _error_.
-	 * - `false`: The PID applies the proportional calculation on the _measurement_.
-	 *
-	 * Setting this value to `false` may help the PID move smoother and help
-	 * eliminate overshoot.
-	 */
-	POnE: boolean;
-
-	/**
 	 * Calculates the new output based on the setpoint and input.
 	 *
 	 * @param setpoint The goal for the PID.
-	 * @param input The current input.
+	 * @param processVariable The measured value of the system to compare against the setpoint.
 	 * @param deltaTime Delta time.
 	 * @returns The updated output.
 	 */
-	Calculate(setpoint: number, input: number, deltaTime: number): number;
+	Calculate(setpoint: number, processVariable: number, deltaTime: number): number;
 
 	/**
 	 * Resets the PID.

--- a/modules/pid/init.lua
+++ b/modules/pid/init.lua
@@ -31,9 +31,9 @@ PID.__index = PID
 --[=[
 	@param min number -- Minimum value the PID can output
 	@param max number -- Maximum value the PID can output
-	@param kp number -- Proportional coefficient
-	@param ki number -- Integral coefficient
-	@param kd number -- Derivative coefficient
+	@param kp number -- Proportional coefficient (P)
+	@param ki number -- Integral coefficient (I)
+	@param kd number -- Derivative coefficient (D)
 	@return PID
 
 	Constructs a new PID.
@@ -46,11 +46,11 @@ function PID.new(min: number, max: number, kp: number, ki: number, kd: number): 
 	local self = setmetatable({}, PID)
 	self._min = min
 	self._max = max
-	self._kp = kp       -- Proportional coefficient (P)
-	self._ki = ki       -- Integral coefficient (I)
-	self._kd = kd       -- Derivative coefficient (D)
-	self._lastError = 0     -- Store the last error for derivative calculation
-	self._integralSum = 0   -- Store the sum Σ of errors for integral calculation
+	self._kp = kp
+	self._ki = ki
+	self._kd = kd
+	self._lastError = 0		-- Store the last error for derivative calculation
+	self._integralSum = 0	-- Store the sum Σ of errors for integral calculation
 	return self
 end
 

--- a/modules/pid/init.lua
+++ b/modules/pid/init.lua
@@ -17,11 +17,6 @@ export type PID = {
 	A common example is a car's cruise control, which would give a PID the current speed
 	and the desired speed, and the PID controller would return the desired throttle input to reach the
 	desired speed.
-
-	Original code based upon the [Arduino PID Library](https://github.com/br3ttb/Arduino-PID-Library).
-
-    Calculations were rewritten by ΣTΞCH to more closely follow PID conventions.
-    This means the removal of the POnE parameter as well as the calculation of the D controller on the error as opposed to the process variable.
 ]=]
 local PID = {}
 PID.__index = PID

--- a/modules/pid/init.lua
+++ b/modules/pid/init.lua
@@ -85,18 +85,18 @@ function PID:Calculate(setpoint: number, processVariable: number, deltaTime: num
 	local err = setpoint - processVariable
 
 	-- Proportional term
-	local P_out = self._kp * err
+	local pOut = self._kp * err
 
 	-- Integral term
 	self._integralSum = self._integralSum + err * deltaTime
-	local I_out = self._ki * self._integralSum
+	local iOut = self._ki * self._integralSum
 
 	-- Derivative term
 	local derivative = (err - self._lastError) / deltaTime
-	local D_out = self._kd * derivative
+	local dOut = self._kd * derivative
 
-	-- Σ Combine terms
-	local output = P_out + I_out + D_out
+	-- Combine terms
+	local output = pOut + iOut + dOut
 
 	-- Clamp output to min/max
 	output = math.clamp(output, self._min, self._max)

--- a/modules/pid/init.lua
+++ b/modules/pid/init.lua
@@ -9,8 +9,6 @@ export type PID = {
 
 --[=[
 	@class PID
-    Authors: Sleitnick, ΣTΞCH (SigmaTech)
-
 	The PID class simulates a [PID controller](https://en.wikipedia.org/wiki/PID_controller). PID is an acronym
 	for _proportional, integral, derivative_. PIDs are input feedback loops that try to reach a specific
 	goal by measuring the difference between the input and the desired value, and then returning a new

--- a/modules/pid/init.lua
+++ b/modules/pid/init.lua
@@ -49,7 +49,7 @@ function PID.new(min: number, max: number, kp: number, ki: number, kd: number): 
 	self._kp = kp
 	self._ki = ki
 	self._kd = kd
-	self._lastError = 0		-- Store the last error for derivative calculation
+	self._lastError = 0	-- Store the last error for derivative calculation
 	self._integralSum = 0	-- Store the sum Σ of errors for integral calculation
 	return self
 end
@@ -63,9 +63,9 @@ function PID:Reset()
 end
 
 --[=[
-	@param setpoint number          -- The desired point to reach
-	@param processVariable number   -- The measured value of the system to compare against the setpoint
-	@param deltaTime number         -- Delta time. This is the time between each PID calculation
+	@param setpoint number	-- The desired point to reach
+	@param processVariable number	-- The measured value of the system to compare against the setpoint
+	@param deltaTime number	-- Delta time. This is the time between each PID calculation
 	@return output: number
 
 	Calculates the new output based on the setpoint and input. For example,

--- a/modules/pid/init.lua
+++ b/modules/pid/init.lua
@@ -84,17 +84,17 @@ end
 ]=]
 function PID:Calculate(setpoint: number, processVariable: number, deltaTime: number)
 	-- Calculate the error e(t) = SP - PV(t)
-	local error = setpoint - processVariable
+	local err = setpoint - processVariable
 
 	-- Proportional term
-	local P_out = self._kp * error
+	local P_out = self._kp * err
 
 	-- Integral term
-	self._integralSum = self._integralSum + error * deltaTime
+	self._integralSum = self._integralSum + err * deltaTime
 	local I_out = self._ki * self._integralSum
 
 	-- Derivative term
-	local derivative = (error - self._lastError) / deltaTime
+	local derivative = (err - self._lastError) / deltaTime
 	local D_out = self._kd * derivative
 
 	-- Σ Combine terms
@@ -104,7 +104,7 @@ function PID:Calculate(setpoint: number, processVariable: number, deltaTime: num
 	output = math.clamp(output, self._min, self._max)
 
 	-- Save the current error for the next derivative calculation
-	self._lastError = error
+	self._lastError = err
 	return output
 end
 

--- a/modules/pid/init.lua
+++ b/modules/pid/init.lua
@@ -49,8 +49,8 @@ function PID.new(min: number, max: number, kp: number, ki: number, kd: number): 
 	self._kp = kp
 	self._ki = ki
 	self._kd = kd
-	self._lastError = 0	-- Store the last error for derivative calculation
-	self._integralSum = 0	-- Store the sum Σ of errors for integral calculation
+	self._lastError = 0 -- Store the last error for derivative calculation
+	self._integralSum = 0 -- Store the sum Σ of errors for integral calculation
 	return self
 end
 

--- a/modules/pid/package.json
+++ b/modules/pid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rbxutil/pid",
-	"version": "1.2.2",
+	"version": "2.0.0",
 	"main": "init.lua",
 	"repository": "github:Sleitnick/RbxUtil",
 	"license": "MIT",

--- a/modules/pid/package.json
+++ b/modules/pid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rbxutil/pid",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"main": "init.lua",
 	"repository": "github:Sleitnick/RbxUtil",
 	"license": "MIT",

--- a/modules/pid/wally.toml
+++ b/modules/pid/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/pid"
 description = "PID Controller class"
-version = "1.2.1"
+version = "1.2.2"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"

--- a/modules/pid/wally.toml
+++ b/modules/pid/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/pid"
 description = "PID Controller class"
-version = "1.2.2"
+version = "2.0.0"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
Corrects PID calculation to follow PID conventions and terminology. 

1) Removes POnE parameter such that Proportional term always acts on the current error between the setpoint and the input.

2) Corrects Derivative term to calculate based on the rate of change of the error as opposed to the difference in process value, providing a predictive damping effect to improve stability and reduce overshoot.