### PR TITLE
fix: error if cleanup method no longer exists

### DIFF
--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -514,7 +514,10 @@ function Trove._cleanupObject(_self: TroveInternal, object: any, cleanupMethod: 
 	elseif cleanupMethod == THREAD_MARKER then
 		pcall(task.cancel, object)
 	else
-		object[cleanupMethod](object)
+		local objectMethod = object[cleanupMethod]
+		if objectMethod then
+			objectMethod(object)
+		end
 	end
 end
 


### PR DESCRIPTION
I have an issue where I was passing in a method to a Trove, but the method usually is cleaned up by the time the trove wants to clear it, therefore the destroy method no longer exists, so it throws an error. This just checks to make sure the cleanup method exists before we try to use it.