### PR TITLE
fix(trove): allow RBXScriptConnection for Trackable type

### DIFF
--- a/modules/trove/init.lua
+++ b/modules/trove/init.lua
@@ -25,11 +25,12 @@ type TroveInternal = Trove & {
 
 --[=[
 	@within Trove
-	@type Trackable Instance | ConnectionLike | PromiseLike | thread | ((...any) -> ...any) | Destroyable | DestroyableLowercase | Disconnectable | DisconnectableLowercase
+	@type Trackable Instance | RBXScriptConnection | ConnectionLike | PromiseLike | thread | ((...any) -> ...any) | Destroyable | DestroyableLowercase | Disconnectable | DisconnectableLowercase
 	Represents all trackable objects by Trove.
 ]=]
 export type Trackable =
 	Instance
+	| RBXScriptConnection
 	| ConnectionLike
 	| PromiseLike
 	| thread


### PR DESCRIPTION
![image](https://github.com/Sleitnick/RbxUtil/assets/88217028/1eab9ffa-622a-46ee-b399-95098c4122df)

`GetObjectCleanupFunction` already returns "Disconnect" when given `RBXScriptConnection`
The problem was type `Trackable` wouldn't convert a `RBXScriptConnection` into a `ConnectionLike` implicitly