### PR TITLE
Fix a typo in documentation

### DIFF
--- a/modules/shake/init.luau
+++ b/modules/shake/init.luau
@@ -424,7 +424,7 @@ end
 
 	Bind the `Update` method to RenderStep.
 
-	All bond functions are cleaned up when the shake instance is stopped
+	All bound functions are cleaned up when the shake instance is stopped
 	or destroyed.
 
 	```lua


### PR DESCRIPTION
"bond" -> "bound"