### PR TITLE
Fixed Signal/PlayerSignal type error

### DIFF
--- a/modules/typed-remote/init.luau
+++ b/modules/typed-remote/init.luau
@@ -1,12 +1,5 @@
 --!strict
 
-type Signal<T...> = {
-	Connect: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	ConnectParallel: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	Once: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	Wait: (self: PlayerSignal<T...>) -> T...,
-}
-
 type PlayerSignal<T...> = {
 	Connect: (self: PlayerSignal<T...>, fn: (player: Player, T...) -> ()) -> RBXScriptConnection,
 	ConnectParallel: (self: PlayerSignal<T...>, fn: (player: Player, T...) -> ()) -> RBXScriptConnection,
@@ -18,14 +11,14 @@ type PlayerSignal<T...> = {
 	@within TypedRemote
 	@interface Event<T...>
 	.OnClientEvent PlayerSignal<T...>,
-	.OnServerEvent Signal<T...>,
+	.OnServerEvent PlayerSignal<T...>,
 	.FireClient (self: Event<T...>, player: Player, T...) -> (),
 	.FireAllClients (self: Event<T...>, T...) -> (),
 	.FireServer (self: Event<T...>, T...) -> (),
 ]=]
 export type Event<T...> = Instance & {
 	OnClientEvent: PlayerSignal<T...>,
-	OnServerEvent: Signal<T...>,
+	OnServerEvent: PlayerSignal<T...>,
 	FireClient: (self: Event<T...>, player: Player, T...) -> (),
 	FireAllClients: (self: Event<T...>, T...) -> (),
 	FireServer: (self: Event<T...>, T...) -> (),


### PR DESCRIPTION
Addresses the following type error on TypedRemoteEvent:

TypeError: Type
    'Signal<number>'
could not be converted into
    'PlayerSignal<number>'
    
### Before:
![image](https://github.com/user-attachments/assets/4052b371-114e-493a-ac63-81c1a1165c22)

### After:
![image](https://github.com/user-attachments/assets/05d019e5-5c28-4e49-9511-a83dd3bd5602)
