### PR TITLE
Corrects Signal + Event.OnClientEvent: PlayerSignal + Event.OnServerEvent: Signal type errors

### DIFF
--- a/modules/typed-remote/init.luau
+++ b/modules/typed-remote/init.luau
@@ -1,12 +1,5 @@
 --!strict
 
-type Signal<T...> = {
-	Connect: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	ConnectParallel: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	Once: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	Wait: (self: PlayerSignal<T...>) -> T...,
-}
-
 type PlayerSignal<T...> = {
 	Connect: (self: PlayerSignal<T...>, fn: (player: Player, T...) -> ()) -> RBXScriptConnection,
 	ConnectParallel: (self: PlayerSignal<T...>, fn: (player: Player, T...) -> ()) -> RBXScriptConnection,
@@ -18,14 +11,14 @@ type PlayerSignal<T...> = {
 	@within TypedRemote
 	@interface Event<T...>
 	.OnClientEvent PlayerSignal<T...>,
-	.OnServerEvent Signal<T...>,
+	.OnServerEvent PlayerSignal<T...>,
 	.FireClient (self: Event<T...>, player: Player, T...) -> (),
 	.FireAllClients (self: Event<T...>, T...) -> (),
 	.FireServer (self: Event<T...>, T...) -> (),
 ]=]
 export type Event<T...> = Instance & {
 	OnClientEvent: PlayerSignal<T...>,
-	OnServerEvent: Signal<T...>,
+	OnServerEvent: PlayerSignal<T...>,
 	FireClient: (self: Event<T...>, player: Player, T...) -> (),
 	FireAllClients: (self: Event<T...>, T...) -> (),
 	FireServer: (self: Event<T...>, T...) -> (),

--- a/modules/typed-remote/init.luau
+++ b/modules/typed-remote/init.luau
@@ -1,5 +1,12 @@
 --!strict
 
+type Signal<T...> = {
+	Connect: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
+	ConnectParallel: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
+	Once: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
+	Wait: (self: PlayerSignal<T...>) -> T...,
+}
+
 type PlayerSignal<T...> = {
 	Connect: (self: PlayerSignal<T...>, fn: (player: Player, T...) -> ()) -> RBXScriptConnection,
 	ConnectParallel: (self: PlayerSignal<T...>, fn: (player: Player, T...) -> ()) -> RBXScriptConnection,
@@ -11,14 +18,14 @@ type PlayerSignal<T...> = {
 	@within TypedRemote
 	@interface Event<T...>
 	.OnClientEvent PlayerSignal<T...>,
-	.OnServerEvent PlayerSignal<T...>,
+	.OnServerEvent Signal<T...>,
 	.FireClient (self: Event<T...>, player: Player, T...) -> (),
 	.FireAllClients (self: Event<T...>, T...) -> (),
 	.FireServer (self: Event<T...>, T...) -> (),
 ]=]
 export type Event<T...> = Instance & {
 	OnClientEvent: PlayerSignal<T...>,
-	OnServerEvent: PlayerSignal<T...>,
+	OnServerEvent: Signal<T...>,
 	FireClient: (self: Event<T...>, player: Player, T...) -> (),
 	FireAllClients: (self: Event<T...>, T...) -> (),
 	FireServer: (self: Event<T...>, T...) -> (),

--- a/modules/typed-remote/init.luau
+++ b/modules/typed-remote/init.luau
@@ -1,10 +1,10 @@
 --!strict
 
 type Signal<T...> = {
-	Connect: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	ConnectParallel: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	Once: (self: PlayerSignal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
-	Wait: (self: PlayerSignal<T...>) -> T...,
+	Connect: (self: Signal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
+	ConnectParallel: (self: Signal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
+	Once: (self: Signal<T...>, fn: (T...) -> ()) -> RBXScriptConnection,
+	Wait: (self: Signal<T...>) -> T...,
 }
 
 type PlayerSignal<T...> = {
@@ -17,15 +17,15 @@ type PlayerSignal<T...> = {
 --[=[
 	@within TypedRemote
 	@interface Event<T...>
-	.OnClientEvent PlayerSignal<T...>,
-	.OnServerEvent Signal<T...>,
+	.OnClientEvent Signal<T...>,
+	.OnServerEvent PlayerSignal<T...>,
 	.FireClient (self: Event<T...>, player: Player, T...) -> (),
 	.FireAllClients (self: Event<T...>, T...) -> (),
 	.FireServer (self: Event<T...>, T...) -> (),
 ]=]
 export type Event<T...> = Instance & {
-	OnClientEvent: PlayerSignal<T...>,
-	OnServerEvent: Signal<T...>,
+	OnClientEvent: Signal<T...>,
+	OnServerEvent: PlayerSignal<T...>,
 	FireClient: (self: Event<T...>, player: Player, T...) -> (),
 	FireAllClients: (self: Event<T...>, T...) -> (),
 	FireServer: (self: Event<T...>, T...) -> (),


### PR DESCRIPTION
## 1. Corrects `Signal` type definition
`Signal` referred to its `self` as `PlayerSignal` instead of `Signal`. 
`self: PlayerSignal` has been changed to `self: Signal` to correct type errors

![image](https://github.com/user-attachments/assets/0415a847-3297-4f5f-891d-f37e685cded4)

## 2. Corrects `Event.OnClientEvent` type from `PlayerSignal` to `Signal`
.OnClientEvent does not carry a `Player` as its first argument and therefore needs to use `Signal` rather than `PlayerSignal`

## 3. Corrects `Event.OnServerEvent` type from `Signal` to `PlayerSignal`
.OnServerEvent requires a `Player` as its first argument and therefore needs to use `PlayerSignal` rather than `Signal`

It is entirely possible that these two simply got mixed up:

![image](https://github.com/user-attachments/assets/bf049e67-70e8-450c-a9dd-59e87fa95d78)
![image](https://github.com/user-attachments/assets/cf469a7c-f884-434a-affb-93983b4d987c)
