### PR TITLE
Troves spawn cleanup functions (solution for #209)

### DIFF
--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -544,7 +544,7 @@ end
 
 function Trove._cleanupObject(_self: TroveInternal, object: any, cleanupMethod: string?)
 	if cleanupMethod == FN_MARKER then
-		object()
+		task.spawn(object)
 	elseif cleanupMethod == THREAD_MARKER then
 		pcall(task.cancel, object)
 	else


### PR DESCRIPTION
This PR proposes a change where adding a yielding or erroring function to a trove will not block other tasks added to that trove from cleaning up.

See #209 for a further description of this problem.

This example highlights why this change is useful needed:
```lua
trove:Add(function()
    print("Task #1")
end)
trove:Add(function()
    print("Task #2 started")
    task.wait(1)
    print("Task #2 completed (1 second later)")
end)
trove:Add(function()
    print("Task #3")
end)
```

Previously, the output would block any tasks added after Task #2 from cleaning up until task #2 completes:
```txt
> Task #1
> Task #2 started
> Task #2 completed (1 second later)
> Task #3
```

With this change, Task #2 does not block the trove from cleaning up, which saves is more intuitive to the library user, and saves on debugging time to understand the conventional rule of why you can't yield on Task #2:
```txt
> Task #1
> Task #2
> Task #3
> Task #2 completed (1 second later)
```