### PR TITLE
Add `priority` to `:Connect` and `:Once` in Sequent type

### DIFF
--- a/modules/sequent/init.luau
+++ b/modules/sequent/init.luau
@@ -1,7 +1,7 @@
 export type Sequent<T> = {
 	Fire: (self: Sequent<T>, T) -> (),
-	Connect: (self: Sequent<T>, callback: (SequentEvent<T>) -> ()) -> SequentConnection,
-	Once: (self: Sequent<T>, callback: (SequentEvent<T>) -> ()) -> SequentConnection,
+	Connect: (self: Sequent<T>, callback: (SequentEvent<T>) -> (), priority: number) -> SequentConnection,
+	Once: (self: Sequent<T>, callback: (SequentEvent<T>) -> (), priority: number) -> SequentConnection,
 	Cancel: (self: Sequent<T>) -> (),
 	Destroy: (self: Sequent<T>) -> (),
 }


### PR DESCRIPTION
:Connect and :Once types in Sequent were missing priority argument, which was causing an error when not included and error in type checker when included.