### PR TITLE
Fix typing for Map method of TableUtil to work with non-arrays

### DIFF
--- a/modules/table-util/init.luau
+++ b/modules/table-util/init.luau
@@ -264,10 +264,10 @@ end
 	print(t2) --> {A = 20, B = 40, C = 60}
 	```
 ]=]
-local function Map<T, M>(t: { T }, f: (T, number, { T }) -> M): { M }
+local function Map<V, K, M>(t: { [K]: V }, f: (V, K, { [K]: V }) -> M): { [K]: M }
 	assert(type(t) == "table", "First argument must be a table")
 	assert(type(f) == "function", "Second argument must be a function")
-	local newT = table.create(#t)
+	local newT = {}
 	for k, v in t do
 		newT[k] = f(v, k, t)
 	end


### PR DESCRIPTION
Fix typing for Map method of TableUtil to work properly with non-arrays. Doc suggests support for such, and functionally it does work with with maps, but lsp is having a fit over the array notation used to type the function.