### PR TITLE
Fix full-scale config with multiple environments

### DIFF
--- a/modules/log/init.luau
+++ b/modules/log/init.luau
@@ -695,7 +695,7 @@ do
 						canUse = true
 						fallthrough = true
 					end
-					if not fallthrough then
+					if canUse and not fallthrough then
 						assert(
 							not set,
 							("More than one LogConfig mapping matched (%s and %s)"):format(setK or "", k or "")


### PR DESCRIPTION
The documentation states that there is support for multiple environments but doesn't actually check whether the logconfig can be used in the existing environment and throws an error.