### PR TITLE
Fix Option.Wrap typing

### DIFF
--- a/modules/option/init.luau
+++ b/modules/option/init.luau
@@ -481,7 +481,7 @@ Option.None = Option._new()
 
 return (Option :: any) :: {
 	Some: <T>(value: T) -> Option<T>,
-	Wrap: <T>(value: T) -> Option<T>,
+	Wrap: <T>(value: T?) -> Option<T>,
 
 	Is: (obj: any) -> boolean,
 


### PR DESCRIPTION
Related to #220
Accept `T?` instead of `T` so `Option.Wrap(nil)` can be coerced to type of `Option.Wrap(T)`