### PR TITLE
Fix signal:Wait() method when :Fire() is called after :Wait() in a non-suspended coroutine.

### DIFF
--- a/modules/signal/init.luau
+++ b/modules/signal/init.luau
@@ -385,7 +385,10 @@ function Signal:Wait()
 
 	self:Once(function(...)
 		yieldedThreads[thread] = nil
-		task.spawn(thread, ...)
+
+		if coroutine.status(thread) == "suspended" then
+			task.spawn(thread, ...)
+		end
 	end)
 
 	return coroutine.yield()


### PR DESCRIPTION
Fixes the error "cannot spawn non-suspended coroutine with arguments", as seen in https://www.youtube.com/watch?v=yevAvHU3ewo

The coroutine's status is now checked before spawning it in :Wait().