### PR TITLE
fix: FireDeferred check for item later

### DIFF
--- a/modules/signal/init.luau
+++ b/modules/signal/init.luau
@@ -346,16 +346,16 @@ end
 	```
 ]=]
 function Signal:FireDeferred(...)
-	local item = self._handlerListHead
-	while item do
-		local conn = item
-		task.defer(function(...)
+	task.defer(function(...)
+		local item = self._handlerListHead
+		while item do
+			local conn = item
 			if conn.Connected then
 				conn._fn(...)
 			end
-		end, ...)
-		item = item._next
-	end
+			item = item._next
+		end
+	end, ...)
 end
 
 --[=[


### PR DESCRIPTION
Currently, FireDeferred does not work in the following example but you would assume it does
```
local signal = Signal.new()
signal:FireDeferred(true)
signal:Connect(print)
```

With this pull request it now does. Also, why doesn't FireDeferred just do `task.defer(Signal.Fire, self, ...)` ?