### PR TITLE
Update init.luau to add "ConnectFunctions" method

### DIFF
--- a/modules/loader/init.luau
+++ b/modules/loader/init.luau
@@ -122,16 +122,35 @@ end
 	)
 	```
 ]=]
-function Loader.SpawnAll(loadedModules: { [string]: any }, methodName: string)
+function Loader.SpawnAll(loadedModules: { [string]: any }, methodName: string, ...)
+	local args = {...}
 	for name, mod in loadedModules do
 		local method = mod[methodName]
 		if type(method) == "function" then
 			task.spawn(function()
 				debug.setmemorycategory(name)
-				method(mod)
+				method(mod, table.unpack(args))
 			end)
 		end
 	end
+end
+
+--[=[
+	Connects the specified event to all provided modules that have a method matching `methodName`.
+	When the event fires, the method will be called in all applicable modules using `task.spawn` to
+	avoid yielding the event thread.
+
+	For example:
+	```lua
+	local modules = Loader.LoadDescendants(MyModules, Loader.MatchesName("Service$"))
+	Loader.ConnectFunctions(modules, Players.PlayerAdded, "OnPlayerAdded")
+	```
+	This will call `OnPlayerAdded(player)` in all matched modules whenever a player joins.
+]=]
+function Loader.ConnectFunctions(loadedModules: { [string]: any }, event: RBXScriptSignal, methodName: string)
+	event:Connect(function(...)
+		Loader.SpawnAll(loadedModules, methodName, ...)
+	end)
 end
 
 return Loader


### PR DESCRIPTION
The Loader module is great for making quick frameworks. However, I find it useful in my own projects to have some additional code that looks for common methods like `Players.PlayerAdded` and connects them in the initialization process rather than connecting multiple events in each module.

This update adds the necessary code to the Loader utility module to make it easy to do the above. For example:

```luau
local ReplicatedStorage = game:GetService("ReplicatedStorage")
local Players = game:GetService("Players")

local Loader = require(ReplicatedStorage.Loader)
local LoadedModules = Loader.LoadDescendants(ReplicatedStorage, Loader.MatchesName("Service$"))

Loader.SpawnAll(LoadedModules, "OnStart")
Loader.ConnectFunctions(LoadedModules, Players.PlayerAdded, "OnPlayerAdded")
```