### PR TITLE
`Instance` objects should be in a weak table

### DIFF
--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -19,6 +19,7 @@ export type Trove = {
 
 type TroveInternal = Trove & {
 	_objects: { any },
+	_instances: { Instance },
 	_cleaning: boolean,
 	_findAndRemoveFromObjects: (self: TroveInternal, object: any, cleanup: boolean) -> boolean,
 	_cleanupObject: (self: TroveInternal, object: any, cleanupMethod: string?) -> (),
@@ -181,6 +182,10 @@ function Trove.new(): Trove
 	local self = setmetatable({}, Trove)
 
 	self._objects = {}
+	self._instances = setmetatable({}, {
+		__mode = "v"
+	}) -- weak value table for instances
+
 	self._cleaning = false
 
 	return (self :: any) :: Trove
@@ -485,8 +490,13 @@ function Trove.Clean(self: TroveInternal)
 	for _, obj in self._objects do
 		self:_cleanupObject(obj[1], obj[2])
 	end
+	for _, obj in self._instances do
+		obj:Destroy()
+	end
 
 	table.clear(self._objects)
+	table.clear(self._instances)
+
 	self._cleaning = false
 end
 

--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -246,8 +246,12 @@ function Trove.Add(self: TroveInternal, object: Trackable, cleanupMethod: string
 		error("cannot call trove:Add() while cleaning", 2)
 	end
 
-	local cleanup = GetObjectCleanupFunction(object, cleanupMethod)
-	table.insert(self._objects, { object, cleanup })
+	if typeof(object) == "Instance" then
+		table.insert(self._instances, object)
+	else
+		local cleanup = GetObjectCleanupFunction(object, cleanupMethod)
+		table.insert(self._objects, { object, cleanup })
+	end
 
 	return object
 end


### PR DESCRIPTION
To avoid memory leaking accidentally, Instances will no longer create a strong reference in troves. This allows the garbage collector to clean them up if they aren't referenced anywhere else.