### PR TITLE
Add Trove:Forget(object)

### DIFF
--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -11,6 +11,7 @@ export type Trove = {
 	AddPromise: <T>(self: Trove, promise: T & PromiseLike) -> T,
 	Add: <T>(self: Trove, object: T & Trackable, cleanupMethod: string?) -> T,
 	Remove: <T>(self: Trove, object: T & Trackable) -> boolean,
+	Forget: <T>(self: Trove, object: T & Trackable) -> boolean,
 	Clean: (self: Trove) -> (),
 	WrapClean: (self: Trove) -> () -> (),
 	AttachToInstance: (self: Trove, instance: Instance) -> RBXScriptConnection,
@@ -281,7 +282,7 @@ end
 
 	If a function is given, the function will
 	be called with the given arguments.
-	
+
 	The result from either of the two options
 	will be added to the trove.
 
@@ -432,6 +433,26 @@ function Trove.Remove(self: TroveInternal, object: Trackable): boolean
 	end
 
 	return self:_findAndRemoveFromObjects(object, true)
+end
+
+--[=[
+	@method Forget
+	@within Trove
+	@param object any
+	Removes the object from the Trove but does _not_ clean it up.
+
+	```lua
+	local part = Instance.new("Part")
+	trove:Add(part)
+	trove:Forget(part) -- the part is unaffected and the trove will not destroy it when cleaned
+	```
+]=]
+function Trove.Forget(self: TroveInternal, object: Trackable): boolean
+	if self._cleaning then
+		error("cannot call trove:Forget() while cleaning", 2)
+	end
+
+	return self:_findAndRemoveFromObjects(object, false)
 end
 
 --[=[


### PR DESCRIPTION
Sometimes it's useful to just have a Trove "let go" of something without cleaning it up. Perhaps this violates some core principle of how maids are supposed to be designed, but several times I feel I've encountered circumstances where, due to timing or structure, having a Trove release something without cleaning it up was the least mentally complicated thing to do while still ensuring something is tracked. In particular, this capability would be useful when you need to "pass" the responsibility of an object from a Trove to another system (or another trove) as its state changes over time.