### PR TITLE
(Net) Ensure functionality in non-replicated locations

### DIFF
--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -6,6 +6,7 @@ local RunService = game:GetService("RunService")
 	RemoteEvents and RemoteFunctions.
 ]=]
 local Net = {}
+local eventContainer: Instance = nil
 
 --[=[
 	Gets a RemoteEvent with the given name.
@@ -25,15 +26,15 @@ local Net = {}
 function Net:RemoteEvent(name: string): RemoteEvent
 	name = "RE/" .. name
 	if RunService:IsServer() then
-		local r = script:FindFirstChild(name)
+		local r = eventContainer:FindFirstChild(name)
 		if not r then
 			r = Instance.new("RemoteEvent")
 			r.Name = name
-			r.Parent = script
+			r.Parent = eventContainer
 		end
 		return r
 	else
-		local r = script:WaitForChild(name, 10)
+		local r = eventContainer:WaitForChild(name, 10)
 		if not r then
 			error("Failed to find RemoteEvent: " .. name, 2)
 		end
@@ -59,15 +60,15 @@ end
 function Net:UnreliableRemoteEvent(name: string): UnreliableRemoteEvent
 	name = "URE/" .. name
 	if RunService:IsServer() then
-		local r = script:FindFirstChild(name)
+		local r = eventContainer:FindFirstChild(name)
 		if not r then
 			r = Instance.new("UnreliableRemoteEvent")
 			r.Name = name
-			r.Parent = script
+			r.Parent = eventContainer
 		end
 		return r
 	else
-		local r = script:WaitForChild(name, 10)
+		local r = eventContainer:WaitForChild(name, 10)
 		if not r then
 			error("Failed to find UnreliableRemoteEvent: " .. name, 2)
 		end
@@ -135,15 +136,15 @@ end
 function Net:RemoteFunction(name: string): RemoteFunction
 	name = "RF/" .. name
 	if RunService:IsServer() then
-		local r = script:FindFirstChild(name)
+		local r = eventContainer:FindFirstChild(name)
 		if not r then
 			r = Instance.new("RemoteFunction")
 			r.Name = name
-			r.Parent = script
+			r.Parent = eventContainer
 		end
 		return r
 	else
-		local r = script:WaitForChild(name, 10)
+		local r = eventContainer:WaitForChild(name, 10)
 		if not r then
 			error("Failed to find RemoteFunction: " .. name, 2)
 		end
@@ -184,7 +185,7 @@ end
 	and not during runtime.
 ]=]
 function Net:Clean()
-	script:ClearAllChildren()
+	eventContainer:ClearAllChildren()
 end
 
 return Net

--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -12,9 +12,16 @@ local eventContainer: Instance = nil
 if script:IsDescendantOf(ReplicatedStorage) then
 	eventContainer = script
 else
-	eventContainer = Instance.new("Folder")
-	eventContainer.Name = "NetEvents"
-	eventContainer.Parent = ReplicatedStorage
+	if RunService:IsServer() then
+		eventContainer = Instance.new("Folder")
+		eventContainer.Name = "NetEvents"
+		eventContainer.Parent = ReplicatedStorage
+	else
+		eventContainer = ReplicatedStorage:WaitForChild("NetEvents", 10)
+		if not eventContainer then
+			error("Failed to find NetEvents folder in ReplicatedStorage, was Net required on the server?", 2)
+		end
+	end
 end
 
 --[=[

--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -8,7 +8,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 ]=]
 local Net = {}
 
-function getEventContainer(): Instance
+local function getEventContainer(): Instance
 	if script:IsDescendantOf(ReplicatedStorage) then
 		return script
 	end

--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -1,4 +1,5 @@
 local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 --[=[
 	@class Net
@@ -7,6 +8,14 @@ local RunService = game:GetService("RunService")
 ]=]
 local Net = {}
 local eventContainer: Instance = nil
+
+if script:IsDescendantOf(ReplicatedStorage) then
+	eventContainer = script
+else
+	eventContainer = Instance.new("Folder")
+	eventContainer.Name = "NetEvents"
+	eventContainer.Parent = ReplicatedStorage
+end
 
 --[=[
 	Gets a RemoteEvent with the given name.

--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -15,7 +15,12 @@ local function getEventContainer(): Instance
 	end
 
 	if RunService:IsServer() then
-		local eventContainer = Instance.new("Folder")
+		local eventContainer = ReplicatedStorage:FindFirstChild(FOLDER_NAME)
+		if eventContainer then
+			return eventContainer
+		end
+
+		eventContainer = Instance.new("Folder")
 		eventContainer.Name = FOLDER_NAME
 		eventContainer.Parent = ReplicatedStorage
 		return eventContainer

--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -8,6 +8,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 ]=]
 local Net = {}
 
+local FOLDER_NAME = "NetEvents"
 local function getEventContainer(): Instance
 	if script:IsDescendantOf(ReplicatedStorage) then
 		return script
@@ -15,14 +16,14 @@ local function getEventContainer(): Instance
 
 	if RunService:IsServer() then
 		local eventContainer = Instance.new("Folder")
-		eventContainer.Name = "NetEvents"
+		eventContainer.Name = FOLDER_NAME
 		eventContainer.Parent = ReplicatedStorage
 		return eventContainer
 	end
 
-	local eventContainer = ReplicatedStorage:WaitForChild("NetEvents", 10)
+	local eventContainer = ReplicatedStorage:WaitForChild(FOLDER_NAME, 10)
 	if not eventContainer then
-		error("Failed to find NetEvents folder in ReplicatedStorage, has the server made any events yet?", 2)
+		error(`Failed to find {FOLDER_NAME} folder in ReplicatedStorage, has the server made any events yet?`, 2)
 	end
 
 	return eventContainer

--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -8,20 +8,24 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 ]=]
 local Net = {}
 
-local eventContainer: Instance = nil
-if script:IsDescendantOf(ReplicatedStorage) then
-	eventContainer = script
-else
+function getEventContainer(): Instance
+	if script:IsDescendantOf(ReplicatedStorage) then
+		return script
+	end
+
 	if RunService:IsServer() then
-		eventContainer = Instance.new("Folder")
+		local eventContainer = Instance.new("Folder")
 		eventContainer.Name = "NetEvents"
 		eventContainer.Parent = ReplicatedStorage
-	else
-		eventContainer = ReplicatedStorage:WaitForChild("NetEvents", 10)
-		if not eventContainer then
-			error("Failed to find NetEvents folder in ReplicatedStorage, was Net required on the server?", 2)
-		end
+		return eventContainer
 	end
+
+	local eventContainer = ReplicatedStorage:WaitForChild("NetEvents", 10)
+	if not eventContainer then
+		error("Failed to find NetEvents folder in ReplicatedStorage, was Net required on the server?", 2)
+	end
+
+	return eventContainer
 end
 
 --[=[
@@ -40,6 +44,8 @@ end
 	```
 ]=]
 function Net:RemoteEvent(name: string): RemoteEvent
+	local eventContainer = getEventContainer()
+
 	name = "RE/" .. name
 	if RunService:IsServer() then
 		local r = eventContainer:FindFirstChild(name)
@@ -74,6 +80,8 @@ end
 	```
 ]=]
 function Net:UnreliableRemoteEvent(name: string): UnreliableRemoteEvent
+	local eventContainer = getEventContainer()
+
 	name = "URE/" .. name
 	if RunService:IsServer() then
 		local r = eventContainer:FindFirstChild(name)
@@ -150,6 +158,8 @@ end
 	```
 ]=]
 function Net:RemoteFunction(name: string): RemoteFunction
+	local eventContainer = getEventContainer()
+
 	name = "RF/" .. name
 	if RunService:IsServer() then
 		local r = eventContainer:FindFirstChild(name)
@@ -201,7 +211,7 @@ end
 	and not during runtime.
 ]=]
 function Net:Clean()
-	eventContainer:ClearAllChildren()
+	getEventContainer():ClearAllChildren()
 end
 
 return Net

--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -22,7 +22,7 @@ local function getEventContainer(): Instance
 
 	local eventContainer = ReplicatedStorage:WaitForChild("NetEvents", 10)
 	if not eventContainer then
-		error("Failed to find NetEvents folder in ReplicatedStorage, was Net required on the server?", 2)
+		error("Failed to find NetEvents folder in ReplicatedStorage, has the server made any events yet?", 2)
 	end
 
 	return eventContainer

--- a/modules/net/init.luau
+++ b/modules/net/init.luau
@@ -7,8 +7,8 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 	RemoteEvents and RemoteFunctions.
 ]=]
 local Net = {}
-local eventContainer: Instance = nil
 
+local eventContainer: Instance = nil
 if script:IsDescendantOf(ReplicatedStorage) then
 	eventContainer = script
 else

--- a/modules/net/wally.toml
+++ b/modules/net/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/net"
 description = "Static networking module"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 authors = ["Stephen Leitnick"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
### What
In the case of Net not being in ReplicatedStorage, it now uses the "NetEvents" folder (created when necessary) inside ReplicatedStorage to ensure it still works properly

### Why
In a personal project, I am using [Fusion](https://elttob.uk/Fusion) to make a loading screen.
This loading screen fires a RemoteEvent using Net when the client is done loading, for the server to `:LoadCharacter()` them.
Because wally does not have a seperate "*client-dependencies*" field, I am forced to sync [Fusion](https://elttob.uk/Fusion) into the same place as would-be shared dependencies such as Net.
Because Fusion is needed for the loading screen, it needs to be synced into ReplicatedFirst, and in turn Net has to be as well.
When testing this configuration I found out that RemoteEvents do not work in ReplicatedFirst, even though technically Net is present on both the server and client, so the current approach of putting the events inside of the script (in ReplicatedFirst) does not work.