### PR TITLE
Added assert() to Signal

### DIFF
--- a/modules/signal/init.luau
+++ b/modules/signal/init.luau
@@ -211,6 +211,8 @@ end
 	```
 ]=]
 function Signal:Connect(fn)
+	assert(typeof(fn) == "function", "Signal:Connect expects a function.")
+
 	local connection = setmetatable({
 		Connected = true,
 		_signal = self,
@@ -234,6 +236,7 @@ end
 	@return SignalConnection
 ]=]
 function Signal:ConnectOnce(fn)
+	assert(typeof(fn) == "function", "Signal:ConnectOnce expects a function.")
 	return self:Once(fn)
 end
 
@@ -253,6 +256,8 @@ end
 	```
 ]=]
 function Signal:Once(fn)
+	assert(typeof(fn) == "function", "Signal:Once expects a function.")
+
 	local connection
 	local done = false
 


### PR DESCRIPTION
Added a check to make sure :Once, :ConnectOnce and :Connect receive a function so that users do not get confused by the naturally occurring error when they forget to pass a function (like me) or pass something else.