### PR TITLE
Resolve typechecking errors with strict Luau in Trove.

### DIFF
--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -395,7 +395,7 @@ function Trove.Construct<T, A...>(self: Trove, class: Constructable<T, A...>, ..
 	if self._cleaning then
 		error("Cannot call trove:Construct() while cleaning", 2)
 	end
-	
+
 	local object = if type(class) == "table" then class.new(...) else class(...)
 	return self:Add(object :: any)
 end

--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -9,7 +9,6 @@ Trove.__index = Trove
 	A Trove is helpful for tracking any sort of object during
 	runtime that needs to get cleaned up at some point.
 ]=]
-
 export type Trove = typeof(setmetatable(
 	{} :: {
 		_objects: { any },
@@ -396,12 +395,8 @@ function Trove.Construct<T, A...>(self: Trove, class: Constructable<T, A...>, ..
 	if self._cleaning then
 		error("Cannot call trove:Construct() while cleaning", 2)
 	end
-
-	-- stylua: ignore
-	local object = if type(class) == "table"
-		then class.new(...)
-		else class(...)
 	
+	local object = if type(class) == "table" then class.new(...) else class(...)
 	return self:Add(object :: any)
 end
 

--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -1,6 +1,45 @@
 --!strict
 local RunService = game:GetService("RunService")
 
+
+--[=[
+	@class Trove
+	A Trove is helpful for tracking any sort of object during
+	runtime that needs to get cleaned up at some point.
+]=]
+local Trove = {}
+Trove.__index = Trove
+
+export type Trove = typeof(setmetatable({} :: {
+	_objects: { any },
+	_cleaning: boolean,
+}, Trove))
+
+--[=[
+	@within Trove
+	@type Trackable<T = any, A... = ...any> Instance | RBXScriptConnection | ConnectionLike<T> | ConnectLikeMetatable<T> | PromiseLike<T> | PromiseLikeMetatable<T> | thread | ((...any) -> ...any) | Destroyable<T> | DestroyableMetatable<T> | DestroyableLowercase<T> | DestroyableLowercaseMetatable<T> | Disconnectable<T> | DisconnectableMetatable<T> | DisconnectableLowercase<T> | DisconnectableLowercaseMetatable<T> | SignalLike<A...> | SignalLikeMetatable<A...>
+	Represents all trackable objects by Trove.
+]=]
+export type Trackable<T = any, A... = ...any> =
+	| Instance
+	| RBXScriptConnection
+	| ConnectionLike<T>
+	| ConnectionLikeMetatable<T>
+	| PromiseLike<T>
+	| PromiseLikeMetatable<T>
+	| thread
+	| ((...any) -> ...any)
+	| Destroyable<T>
+	| DestroyableMetatable<T>
+	| DestroyableLowercase<T>
+	| DestroyableLowercaseMetatable<T>
+	| Disconnectable<T>
+	| DisconnectableMetatable<T>
+	| DisconnectableLowercase<T>
+	| DisconnectableLowercaseMetatable<T>
+	| SignalLike<A...>
+	| SignalLikeMetatable<A...>
+
 --[=[
 	@within Trove
 	@interface ConnectionLike<T = any>
@@ -167,43 +206,6 @@ type Cloneable<T = any> = {
 ]=]
 type CloneableMetatable<T = any> = typeof(setmetatable({}, {} :: Cloneable<T>))
 
---[=[
-	@within Trove
-	@type Trackable<T = any, A... = ...any> Instance | RBXScriptConnection | ConnectionLike<T> | ConnectLikeMetatable<T> | PromiseLike<T> | PromiseLikeMetatable<T> | thread | ((...any) -> ...any) | Destroyable<T> | DestroyableMetatable<T> | DestroyableLowercase<T> | DestroyableLowercaseMetatable<T> | Disconnectable<T> | DisconnectableMetatable<T> | DisconnectableLowercase<T> | DisconnectableLowercaseMetatable<T> | SignalLike<A...> | SignalLikeMetatable<A...>
-	Represents all trackable objects by Trove.
-]=]
-export type Trackable<T = any, A... = ...any> =
-	| Instance
-	| RBXScriptConnection
-	| ConnectionLike<T>
-	| ConnectionLikeMetatable<T>
-	| PromiseLike<T>
-	| PromiseLikeMetatable<T>
-	| thread
-	| ((...any) -> ...any)
-	| Destroyable<T>
-	| DestroyableMetatable<T>
-	| DestroyableLowercase<T>
-	| DestroyableLowercaseMetatable<T>
-	| Disconnectable<T>
-	| DisconnectableMetatable<T>
-	| DisconnectableLowercase<T>
-	| DisconnectableLowercaseMetatable<T>
-	| SignalLike<A...>
-	| SignalLikeMetatable<A...>
-
---[=[
-	@class Trove
-	A Trove is helpful for tracking any sort of object during
-	runtime that needs to get cleaned up at some point.
-]=]
-local Trove = {}
-Trove.__index = Trove
-
-export type Trove = typeof(setmetatable({} :: {
-	_objects: { any },
-	_cleaning: boolean,
-}, Trove))
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
@@ -235,36 +237,6 @@ local function getObjectCleanupFunction(object: any, cleanupMethod: string?)
 	end
 
 	error(`failed to get cleanup function for object {t}: {object}`, 3)
-end
-
-function Trove._cleanupObject(self: Trove, object: any, cleanupMethod: string?)
-	if cleanupMethod == FN_MARKER then
-		task.spawn(object)
-	elseif cleanupMethod == THREAD_MARKER then
-		pcall(task.cancel, object)
-	else
-		object[cleanupMethod](object)
-	end
-end
-
-function Trove._findAndRemoveFromObjects(self: Trove, object: any, cleanup: boolean): boolean
-	local objects = self._objects
-
-	for i, obj in objects do
-		if obj[1] == object then
-			local n = #objects
-			objects[i] = objects[n]
-			objects[n] = nil
-
-			if cleanup then
-				self:_cleanupObject(obj[1], obj[2])
-			end
-
-			return true
-		end
-	end
-
-	return false
 end
 
 local function assertPromiseLike(object: any)
@@ -309,7 +281,7 @@ end
 	@within Trove
 	@param object Trackable<T> -- Object to track
 	@param cleanupMethod string? -- Optional cleanup name override
-	@return object: any
+	@return object: T
 	Adds an object to the trove. Once the trove is cleaned or
 	destroyed, the object will also be cleaned up.
 
@@ -368,21 +340,21 @@ end
 --[=[
 	@method Clone
 	@within Trove
+	@param object Instance | Cloneable<T> | CloneableMetatable<T>
 	@return T
-	@param instance Instance | Cloneable<T> | CloneableMetatable<T>
-	Clones the given instance and adds it to the trove. Shorthand for
-	`trove:Add(instance:Clone())`.
+	Clones the given object and adds it to the trove. Shorthand for
+	`trove:Add(object:Clone())`.
 
 	```lua
 	local clonedPart = trove:Clone(somePart)
 	```
 ]=]
-function Trove.Clone<T>(self: Trove, instance: Instance | Cloneable<T> | CloneableMetatable<T>): T
+function Trove.Clone<T>(self: Trove, object: Instance | Cloneable<T> | CloneableMetatable<T>): T
 	if self._cleaning then
 		error("cannot call trove:Clone() while cleaning", 2)
 	end
 
-	return self:Add((instance :: any):Clone())
+	return self:Add((object :: any):Clone())
 end
 
 --[=[
@@ -596,7 +568,7 @@ function Trove.Remove<T>(self: Trove, object: Trackable<T>): boolean
 		error("cannot call trove:Remove() while cleaning", 2)
 	end
 
-	return self:_findAndRemoveFromObjects(self, object, true)
+	return self:_findAndRemoveFromObjects(object, true)
 end
 
 --[=[
@@ -618,7 +590,7 @@ function Trove.Pop<T>(self: Trove, object: Trackable<T>): boolean
 		error("cannot call trove:Pop() while cleaning", 2)
 	end
 
-	return self:_findAndRemoveFromObjects(self, object, false)
+	return self:_findAndRemoveFromObjects(object, false)
 end
 
 --[=[
@@ -710,6 +682,36 @@ function Trove.WrapClean(self: Trove)
 	end
 end
 
+function Trove._findAndRemoveFromObjects(self: Trove, object: any, cleanup: boolean): boolean
+	local objects = self._objects
+
+	for i, obj in objects do
+		if obj[1] == object then
+			local n = #objects
+			objects[i] = objects[n]
+			objects[n] = nil
+
+			if cleanup then
+				self:_cleanupObject(obj[1], obj[2])
+			end
+
+			return true
+		end
+	end
+
+	return false
+end
+
+function Trove._cleanupObject(self: Trove, object: any, cleanupMethod: string?)
+	if cleanupMethod == FN_MARKER then
+		task.spawn(object)
+	elseif cleanupMethod == THREAD_MARKER then
+		pcall(task.cancel, object)
+	else
+		object[cleanupMethod](object)
+	end
+end
+
 --[=[
 	@method AttachToInstance
 	@within Trove
@@ -766,5 +768,5 @@ function Trove.Destroy(self: Trove)
 end
 
 return {
-	new = Trove.new
+	new = Trove.new,
 }

--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -682,6 +682,8 @@ function Trove.WrapClean(self: Trove)
 	end
 end
 
+--- INTERNAL FUNCTION, DO NOT USE!
+--  FIXME: Just make this a local function if it isn't used elsewhere? Is it used for testing?
 function Trove._findAndRemoveFromObjects(self: Trove, object: any, cleanup: boolean): boolean
 	local objects = self._objects
 
@@ -702,7 +704,9 @@ function Trove._findAndRemoveFromObjects(self: Trove, object: any, cleanup: bool
 	return false
 end
 
-function Trove._cleanupObject(self: Trove, object: any, cleanupMethod: string?)
+--- INTERNAL FUNCTION, DO NOT USE!
+--  FIXME: Just make this a local function if it isn't used elsewhere? Is it used for testing?
+function Trove._cleanupObject(_self: any, object: any, cleanupMethod: string?)
 	if cleanupMethod == FN_MARKER then
 		task.spawn(object)
 	elseif cleanupMethod == THREAD_MARKER then

--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -1,217 +1,207 @@
 --!strict
-
 local RunService = game:GetService("RunService")
 
-export type Trove = {
-	Extend: (self: Trove) -> Trove,
-	Clone: <T>(self: Trove, instance: T & Instance) -> T,
-	Construct: <T, A...>(self: Trove, class: Constructable<T, A...>, A...) -> T,
-	Connect: (
-		self: Trove,
-		signal: SignalLike | SignalLikeMetatable | RBXScriptSignal,
-		fn: (...any) -> ...any
-	) -> ConnectionLike | ConnectionLikeMetatable,
-	BindToRenderStep: (self: Trove, name: string, priority: number, fn: (dt: number) -> ()) -> (),
-	AddPromise: <T>(self: Trove, promise: (T & PromiseLike) | (T & PromiseLikeMetatable)) -> T,
-	Add: <T>(self: Trove, object: T & Trackable, cleanupMethod: string?) -> T,
-	Remove: <T>(self: Trove, object: T & Trackable) -> boolean,
-	Pop: <T>(self: Trove, object: T & Trackable) -> boolean,
-	Clean: (self: Trove) -> (),
-	WrapClean: (self: Trove) -> () -> (),
-	AttachToInstance: (self: Trove, instance: Instance) -> RBXScriptConnection,
-	Destroy: (self: Trove) -> (),
+--[=[
+	@within Trove
+	@interface ConnectionLike<T = any>
+	.Connected boolean
+	.Disconnect (self: T) -> ()
+]=]
+type ConnectionLike<T = any> = {
+	Connected: boolean,
+	Disconnect: (self: T) -> (),
+	Destroy: ((self: T) -> ())?,
 }
 
-type TroveInternal = Trove & {
-	_objects: { any },
-	_cleaning: boolean,
-	_findAndRemoveFromObjects: (self: TroveInternal, object: any, cleanup: boolean) -> boolean,
-	_cleanupObject: (self: TroveInternal, object: any, cleanupMethod: string?) -> (),
+--[=[
+	@within Trove
+	@interface ConnectionLikeMetatable<T = any>
+	.Connected boolean
+	.Disconnect (self: T) -> ()
+	@tag Metatable
+]=]
+type ConnectionLikeMetatable<T = any> = typeof(setmetatable({}, {} :: ConnectionLike<T>))
+
+--[=[
+	@within Trove
+	@interface SignalLike<T = any, A... = ...any>
+	.Connect (self: any, callback: (A...) -> ()) -> ConnectionLike
+	.Once (self: any, callback: (A...) -> ()) -> ConnectionLike
+]=]
+type SignalLike<T... = ...any> = {
+	Connect: (self: any, callback: (T...) -> ()) -> ConnectionLike,
+	Once: (self: any, callback: (T...) -> ()) -> ConnectionLike,
 }
+
+--[=[
+	@within Trove
+	@interface SignalLikeMetatable<T = any, A... = ...any>
+	.Connect (self: T, callback: (T...) -> ()) -> ConnectionLike
+	.Once (self: T, callback: (T...) -> ()) -> ConnectionLike
+	@tag Metatable
+]=]
+type SignalLikeMetatable<T... = ...any> = typeof(setmetatable({}, {} :: {
+	Connect: (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike,
+	Once: (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike,
+}))
+
+--[=[
+	@within Trove
+	@type PromiseLikeStatus
+]=]
+type PromiseLikeStatus =
+	| "Started"
+	| "Resolved"
+	| "Rejected"
+	| "Cancelled"
+	| string
+
+--[=[
+	@within Trove
+	@interface PromiseLike<T = any>
+	.getStatus (self: T) -> string | "Started" | "Resolved" | "Rejected" | "Cancelled"
+	.finally (self: T, callback: (...any) -> ...any) -> T
+	.cancel (self: T) -> ()
+]=]
+type PromiseLike<T = any> = {
+	getStatus: (self: T) -> PromiseLikeStatus,
+	finally: (self: T, callback: (...any) -> ...any) -> T,
+	cancel: (self: T) -> (),
+}
+
+--[=[
+	@within Trove
+	@interface PromiseLikeMetatable<T = any>
+	.getStatus (self: T) -> string | "Started" | "Resolved" | "Rejected" | "Cancelled"
+	.finally (self: T, callback: (...any) -> ...any) -> T
+	.cancel (self: T) -> ()
+	@tag Metatable
+]=]
+type PromiseLikeMetatable<T = any> = typeof(setmetatable({}, {} :: PromiseLike<T>))
+
+--[=[
+	@within Trove
+	@type Constructable<T = any, A... = ...any> { new: (A...) -> T }
+]=]
+type Constructable<T = any, A... = ...any> = { new: (A...) -> T } | (A...) -> T
+
+--[=[
+	@within Trove
+	@interface Destroyable<T = any>
+	.Destroy (self: T) -> ()
+]=]
+type Destroyable<T = any> = {
+	Destroy: (self: T) -> (),
+}
+
+--[=[
+	@within Trove
+	@interface DestroyableMetatable<T = any>
+	.Destroy (self: T) -> ()
+]=]
+type DestroyableMetatable<T = any> = typeof(setmetatable({}, {} :: Destroyable<T>))
+
+--[=[
+	@within Trove
+	@interface DestroyableLowercase<T = any>
+	.destroy (self: T) -> ()
+]=]
+type DestroyableLowercase<T = any> = {
+	destroy: (self: T) -> (),
+}
+
+--[=[
+	@within Trove
+	@interface DestroyableLowercaseMetatable<T = any>
+	.destroy (self: T) -> ()
+]=]
+type DestroyableLowercaseMetatable<T = any> = typeof(setmetatable({}, {} :: DestroyableLowercase<T>))
+
+--[=[
+	@within Trove
+	@interface Disconnectable<T = any>
+	.Disconnect (self: T) -> ()
+]=]
+type Disconnectable<T = any> = {
+	Disconnect: (self: T) -> (),
+}
+
+--[=[
+	@within Trove
+	@interface DisconnectableMetatable<T = any>
+	.Disconnect (self: T) -> ()
+]=]
+type DisconnectableMetatable<T = any> = typeof(setmetatable({}, {} :: Disconnectable<T>))
+
+--[=[
+	@within Trove
+	@interface DisconnectableLowercase<T = any>
+	.disconnect (self: T) -> ()
+]=]
+type DisconnectableLowercase<T = any> = {
+	disconnect: (self: T) -> (),
+}
+
+--[=[
+	@within Trove
+	@interface DisconnectableLowercaseMetatable<T = any>
+	.disconnect (self: T) -> ()
+]=]
+type DisconnectableLowercaseMetatable<T = any> = typeof(setmetatable({}, {} :: DisconnectableLowercase<T>))
+
+--[=[
+	@within Trove
+	@interface Cloneable<T = any>
+	.Clone (self: T) -> T
+]=]
+type Cloneable<T = any> = {
+	Clone: (self: T) -> T,
+}
+
+--[=[
+	@within Trove
+	@interface CloneableMetatable<T = any>
+	.Clone (self: T) -> T
+]=]
+type CloneableMetatable<T = any> = typeof(setmetatable({}, {} :: Cloneable<T>))
 
 --[=[
 	@within Trove
 	@type Trackable Instance | RBXScriptConnection | ConnectionLike | ConnectLikeMetatable | PromiseLike | PromiseLikeMetatable | thread | ((...any) -> ...any) | Destroyable | DestroyableMetatable | DestroyableLowercase | DestroyableLowercaseMetatable | Disconnectable | DisconnectableMetatable | DisconnectableLowercase | DisconnectableLowercaseMetatable | SignalLike | SignalLikeMetatable
 	Represents all trackable objects by Trove.
 ]=]
-export type Trackable =
+export type Trackable<T = any, A... = ...any> =
 	| Instance
 	| RBXScriptConnection
-	| ConnectionLike
-	| ConnectionLikeMetatable
-	| PromiseLike
-	| PromiseLikeMetatable
+	| ConnectionLike<T>
+	| ConnectionLikeMetatable<T>
+	| PromiseLike<T>
+	| PromiseLikeMetatable<T>
 	| thread
 	| ((...any) -> ...any)
-	| Destroyable
-	| DestroyableMetatable
-	| DestroyableLowercase
-	| DestroyableLowercaseMetatable
-	| Disconnectable
-	| DisconectableMetatable
-	| DisconnectableLowercase
-	| DisconnectableLowercaseMetatable
-	| SignalLike
-	| SignalLikeMetatable
+	| Destroyable<T>
+	| DestroyableMetatable<T>
+	| DestroyableLowercase<T>
+	| DestroyableLowercaseMetatable<T>
+	| Disconnectable<T>
+	| DisconnectableMetatable<T>
+	| DisconnectableLowercase<T>
+	| DisconnectableLowercaseMetatable<T>
+	| SignalLike<A...>
+	| SignalLikeMetatable<A...>
 
 --[=[
-	@within Trove
-	@interface ConnectionLike
-	.Connected boolean
-	.Disconnect (self) -> ()
+	@class Trove
+	A Trove is helpful for tracking any sort of object during
+	runtime that needs to get cleaned up at some point.
 ]=]
-type ConnectionLike = {
-	Connected: boolean,
-	Disconnect: (self: ConnectionLike) -> (),
-}
+local Trove = {}
+Trove.__index = Trove
 
---[=[
-	@within Trove
-	@interface ConnectionLikeMetatable
-	.Connected boolean
-	.Disconnect (self) -> ()
-	@tag Metatable
-]=]
-type ConnectionLikeMetatable = typeof(setmetatable(
-	{},
-	{} :: { Connected: boolean, Disconnect: (self: ConnectionLikeMetatable) -> () }
-))
-
---[=[
-	@within Trove
-	@interface SignalLike
-	.Connect (self, callback: (...any) -> ...any) -> ConnectionLike
-	.Once (self, callback: (...any) -> ...any) -> ConnectionLike
-]=]
-type SignalLike = {
-	Connect: (self: SignalLike, callback: (...any) -> ...any) -> ConnectionLike | ConnectionLikeMetatable,
-	Once: (self: SignalLike, callback: (...any) -> ...any) -> ConnectionLike | ConnectionLikeMetatable,
-}
-
---[=[
-	@within Trove
-	@interface SignalLikeMetatable
-	.Connect (self, callback: (...any) -> ...any) -> ConnectionLike
-	.Once (self, callback: (...any) -> ...any) -> ConnectionLike
-	@tag Metatable
-]=]
-type SignalLikeMetatable = typeof(setmetatable(
-	{},
-	{} :: {
-		Connect: (self: SignalLikeMetatable, callback: (...any) -> ...any) -> ConnectionLike | ConnectionLikeMetatable,
-		Once: (self: SignalLikeMetatable, callback: (...any) -> ...any) -> ConnectionLike | ConnectionLikeMetatable,
-	}
-))
-
---[=[
-	@within Trove
-	@interface PromiseLike
-	.getStatus (self) -> string
-	.finally (self, callback: (...any) -> ...any) -> PromiseLike
-	.cancel (self) -> ()
-]=]
-type PromiseLike = {
-	getStatus: (self: PromiseLike) -> string,
-	finally: (self: PromiseLike, callback: (...any) -> ...any) -> PromiseLike | PromiseLikeMetatable,
-	cancel: (self: PromiseLike) -> (),
-}
-
---[=[
-	@within Trove
-	@interface PromiseLikeMetatable
-	.getStatus (self) -> string
-	.finally (self, callback: (...any) -> ...any) -> PromiseLike
-	.cancel (self) -> ()
-	@tag Metatable
-]=]
-type PromiseLikeMetatable = typeof(setmetatable(
-	{},
-	{} :: {
-		getStatus: (self: any) -> string,
-		finally: (self: PromiseLikeMetatable, callback: (...any) -> ...any) -> PromiseLike | PromiseLikeMetatable,
-		cancel: (self: PromiseLikeMetatable) -> (),
-	}
-))
-
---[=[
-	@within Trove
-	@type Constructable { new: (A...) -> T } | (A...) -> T
-]=]
-type Constructable<T, A...> = { new: (A...) -> T } | (A...) -> T
-
---[=[
-	@within Trove
-	@interface Destroyable
-	.Destroy (self) -> ()
-]=]
-type Destroyable = {
-	Destroy: (self: Destroyable) -> (),
-}
-
---[=[
-	@within Trove
-	@interface DestroyableMetatable
-	.Destroy (self) -> ()
-	@tag Metatable
-]=]
-type DestroyableMetatable = typeof(setmetatable({}, {} :: { Destroy: (self: DestroyableMetatable) -> () }))
-
---[=[
-	@within Trove
-	@interface DestroyableLowercase
-	.destroy (self) -> ()
-]=]
-type DestroyableLowercase = {
-	destroy: (self: DestroyableLowercase) -> (),
-}
-
---[=[
-	@within Trove
-	@interface DestroyableLowercaseMetatable
-	.destroy (self) -> ()
-	@tag Metatable
-]=]
-type DestroyableLowercaseMetatable = typeof(setmetatable(
-	{},
-	{} :: { destroy: (self: DestroyableLowercaseMetatable) -> () }
-))
-
---[=[
-	@within Trove
-	@interface Disconnectable
-	.Disconnect (self) -> ()
-]=]
-type Disconnectable = {
-	Disconnect: (self: Disconnectable) -> (),
-}
-
---[=[
-	@within Trove
-	@interface DisconectableMetatable
-	.Disconnect (self) -> ()
-	@tag Metatable
-]=]
-type DisconectableMetatable = typeof(setmetatable({}, {} :: { Disconnect: (self: DisconectableMetatable) -> () }))
-
---[=[
-	@within Trove
-	@interface DisconnectableLowercase
-	.disconnect (self) -> ()
-]=]
-type DisconnectableLowercase = {
-	disconnect: (self: DisconnectableLowercase) -> (),
-}
-
---[=[
-	@within Trove
-	@interface DisconnectableLowercaseMetatable
-	.disconnect (self) -> ()
-	@tag Metatable
-]=]
-type DisconnectableLowercaseMetatable = typeof(setmetatable(
-	{},
-	{} :: { disconnect: (self: DisconnectableLowercaseMetatable) -> () }
-))
+export type Trove = typeof(setmetatable({} :: {
+	_objects: { any },
+	_cleaning: boolean,
+}, Trove))
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
@@ -245,6 +235,36 @@ local function getObjectCleanupFunction(object: any, cleanupMethod: string?)
 	error(`failed to get cleanup function for object {t}: {object}`, 3)
 end
 
+local function cleanupObject(object: any, cleanupMethod: string?)
+	if cleanupMethod == FN_MARKER then
+		task.spawn(object)
+	elseif cleanupMethod == THREAD_MARKER then
+		pcall(task.cancel, object)
+	else
+		object[cleanupMethod](object)
+	end
+end
+
+local function findAndRemoveFromObjects(self: Trove, object: any, cleanup: boolean): boolean
+	local objects = self._objects
+
+	for i, obj in objects do
+		if obj[1] == object then
+			local n = #objects
+			objects[i] = objects[n]
+			objects[n] = nil
+
+			if cleanup then
+				cleanupObject(obj[1], obj[2])
+			end
+
+			return true
+		end
+	end
+
+	return false
+end
+
 local function assertPromiseLike(object: any)
 	if
 		typeof(object) ~= "table"
@@ -266,14 +286,6 @@ local function assertSignalLike(object: any)
 end
 
 --[=[
-	@class Trove
-	A Trove is helpful for tracking any sort of object during
-	runtime that needs to get cleaned up at some point.
-]=]
-local Trove = {}
-Trove.__index = Trove
-
---[=[
 	@return Trove
 	Constructs a Trove object.
 
@@ -282,12 +294,12 @@ Trove.__index = Trove
 	```
 ]=]
 function Trove.new(): Trove
-	local self = setmetatable({}, Trove)
+	local self = setmetatable({
+		_objects = {},
+		_cleaning = false,
+	}, Trove)
 
-	self._objects = {}
-	self._cleaning = false
-
-	return (self :: any) :: Trove
+	return self
 end
 
 --[=[
@@ -340,7 +352,7 @@ end
 	trove:Add(tbl, "DoSomething")
 	```
 ]=]
-function Trove.Add(self: TroveInternal, object: Trackable, cleanupMethod: string?): any
+function Trove.Add<T>(self: Trove, object: Trackable<T>, cleanupMethod: string?): T
 	if self._cleaning then
 		error("cannot call trove:Add() while cleaning", 2)
 	end
@@ -348,7 +360,7 @@ function Trove.Add(self: TroveInternal, object: Trackable, cleanupMethod: string
 	local cleanup = getObjectCleanupFunction(object, cleanupMethod)
 	table.insert(self._objects, { object, cleanup })
 
-	return object
+	return object :: any
 end
 
 --[=[
@@ -362,12 +374,12 @@ end
 	local clonedPart = trove:Clone(somePart)
 	```
 ]=]
-function Trove.Clone(self: TroveInternal, instance: Instance): Instance
+function Trove.Clone<T>(self: Trove, instance: Instance | Cloneable<T> | CloneableMetatable<T>): T
 	if self._cleaning then
 		error("cannot call trove:Clone() while cleaning", 2)
 	end
 
-	return self:Add(instance:Clone())
+	return self:Add((instance :: any):Clone())
 end
 
 --[=[
@@ -405,20 +417,16 @@ end
 	local part = trove:Construct(Instance, "Part")
 	```
 ]=]
-function Trove.Construct<T, A...>(self: TroveInternal, class: Constructable<T, A...>, ...: A...)
+function Trove.Construct<T, A...>(self: Trove, class: Constructable<T, A...>, ...: A...): T
 	if self._cleaning then
 		error("Cannot call trove:Construct() while cleaning", 2)
 	end
 
-	local object = nil
-	local t = type(class)
-	if t == "table" then
-		object = (class :: any).new(...)
-	elseif t == "function" then
-		object = (class :: any)(...)
-	end
-
-	return self:Add(object)
+	local object = if type(class) == "table"
+		then class.new(...)
+		else class(...)
+	
+	return self:Add(object :: any)
 end
 
 --[=[
@@ -438,17 +446,17 @@ end
 	end)
 	```
 ]=]
-function Trove.Connect(
-	self: TroveInternal,
-	signal: SignalLike | SignalLikeMetatable | RBXScriptSignal,
-	fn: (...any) -> ...any
-)
+function Trove.Connect<T...>(
+	self: Trove,
+	signal: SignalLike<T...> | SignalLikeMetatable<T...> | RBXScriptSignal<T...>,
+	fn: (T...) -> ()
+): ConnectionLike
 	if self._cleaning then
 		error("Cannot call trove:Connect() while cleaning", 2)
 	end
-	assertSignalLike(signal)
 
-	local confirmedSignal = signal :: SignalLike
+	assertSignalLike(signal)
+	local confirmedSignal = signal :: SignalLike<T...>
 
 	return self:Add(confirmedSignal:Connect(fn))
 end
@@ -471,17 +479,17 @@ end
 	end)
 	```
 ]=]
-function Trove.Once(
-	self: TroveInternal,
-	signal: SignalLike | SignalLikeMetatable | RBXScriptSignal,
-	fn: (...any) -> ...any
-)
+function Trove.Once<T...>(
+	self: Trove,
+	signal: SignalLike<T...> | SignalLikeMetatable<T...> | RBXScriptSignal<T...>,
+	fn: (T...) -> ()
+): ConnectionLike
 	if self._cleaning then
 		error("Cannot call trove:Connect() while cleaning", 2)
 	end
 	assertSignalLike(signal)
 
-	local confirmedSignal = signal :: SignalLike
+	local confirmedSignal = signal :: SignalLike<T...>
 
 	local conn
 	conn = confirmedSignal:Once(function(...)
@@ -507,7 +515,7 @@ end
 	end)
 	```
 ]=]
-function Trove.BindToRenderStep(self: TroveInternal, name: string, priority: number, fn: (dt: number) -> ())
+function Trove.BindToRenderStep(self: Trove, name: string, priority: number, fn: (dt: number) -> ())
 	if self._cleaning then
 		error("cannot call trove:BindToRenderStep() while cleaning", 2)
 	end
@@ -544,10 +552,11 @@ end
 	This is only compatible with the [roblox-lua-promise](https://eryn.io/roblox-lua-promise/) library, version 4.
 	:::
 ]=]
-function Trove.AddPromise(self: TroveInternal, promise: PromiseLike | PromiseLikeMetatable)
+function Trove.AddPromise<T>(self: Trove, promise: PromiseLike<T>): T
 	if self._cleaning then
 		error("cannot call trove:AddPromise() while cleaning", 2)
 	end
+
 	assertPromiseLike(promise)
 	local confirmedPromise = promise :: PromiseLike
 
@@ -556,13 +565,14 @@ function Trove.AddPromise(self: TroveInternal, promise: PromiseLike | PromiseLik
 			if self._cleaning then
 				return
 			end
-			self:_findAndRemoveFromObjects(confirmedPromise, false)
+
+			findAndRemoveFromObjects(self, confirmedPromise, false)
 		end)
 
 		self:Add(confirmedPromise, "cancel")
 	end
 
-	return confirmedPromise
+	return confirmedPromise :: any
 end
 
 --[=[
@@ -578,12 +588,12 @@ end
 	trove:Remove(part) -- Part is destroyed
 	```
 ]=]
-function Trove.Remove(self: TroveInternal, object: Trackable): boolean
+function Trove.Remove<T>(self: Trove, object: Trackable<T>): boolean
 	if self._cleaning then
 		error("cannot call trove:Remove() while cleaning", 2)
 	end
 
-	return self:_findAndRemoveFromObjects(object, true)
+	return findAndRemoveFromObjects(self, object, true)
 end
 
 --[=[
@@ -600,12 +610,12 @@ end
 	trove:Clean() -- Part is NOT destroyed
 	```
 ]=]
-function Trove.Pop(self: TroveInternal, object: Trackable): boolean
+function Trove.Pop<T>(self: Trove, object: Trackable<T>): boolean
 	if self._cleaning then
 		error("cannot call trove:Pop() while cleaning", 2)
 	end
 
-	return self:_findAndRemoveFromObjects(object, false)
+	return findAndRemoveFromObjects(self, object, false)
 end
 
 --[=[
@@ -629,7 +639,7 @@ end
 	trove:Clean() -- Cleans up the subTrove too
 	```
 ]=]
-function Trove.Extend(self: TroveInternal)
+function Trove.Extend(self: Trove): Trove
 	if self._cleaning then
 		error("cannot call trove:Extend() while cleaning", 2)
 	end
@@ -649,7 +659,7 @@ end
 	trove:Clean()
 	```
 ]=]
-function Trove.Clean(self: TroveInternal)
+function Trove.Clean(self: Trove)
 	if self._cleaning then
 		return
 	end
@@ -657,7 +667,7 @@ function Trove.Clean(self: TroveInternal)
 	self._cleaning = true
 
 	for _, obj in self._objects do
-		self:_cleanupObject(obj[1], obj[2])
+		cleanupObject(obj[1], obj[2])
 	end
 
 	table.clear(self._objects)
@@ -691,39 +701,9 @@ end
 	end)
 	```
 ]=]
-function Trove.WrapClean(self: TroveInternal)
+function Trove.WrapClean(self: Trove)
 	return function()
 		self:Clean()
-	end
-end
-
-function Trove._findAndRemoveFromObjects(self: TroveInternal, object: any, cleanup: boolean): boolean
-	local objects = self._objects
-
-	for i, obj in objects do
-		if obj[1] == object then
-			local n = #objects
-			objects[i] = objects[n]
-			objects[n] = nil
-
-			if cleanup then
-				self:_cleanupObject(obj[1], obj[2])
-			end
-
-			return true
-		end
-	end
-
-	return false
-end
-
-function Trove._cleanupObject(_self: TroveInternal, object: any, cleanupMethod: string?)
-	if cleanupMethod == FN_MARKER then
-		task.spawn(object)
-	elseif cleanupMethod == THREAD_MARKER then
-		pcall(task.cancel, object)
-	else
-		object[cleanupMethod](object)
 	end
 end
 
@@ -757,7 +737,7 @@ end
 	somePart:Destroy()
 	```
 ]=]
-function Trove.AttachToInstance(self: TroveInternal, instance: Instance)
+function Trove.AttachToInstance(self: Trove, instance: Instance)
 	if self._cleaning then
 		error("cannot call trove:AttachToInstance() while cleaning", 2)
 	elseif not instance:IsDescendantOf(game) then
@@ -778,10 +758,10 @@ end
 	trove:Destroy()
 	```
 ]=]
-function Trove.Destroy(self: TroveInternal)
+function Trove.Destroy(self: Trove)
 	self:Clean()
 end
 
 return {
-	new = Trove.new,
+	new = Trove.new
 }

--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -6,6 +6,7 @@ local RunService = game:GetService("RunService")
 	@interface ConnectionLike<T = any>
 	.Connected boolean
 	.Disconnect (self: T) -> ()
+	.Destroy ((self: T) -> ())?
 ]=]
 type ConnectionLike<T = any> = {
 	Connected: boolean,
@@ -18,15 +19,16 @@ type ConnectionLike<T = any> = {
 	@interface ConnectionLikeMetatable<T = any>
 	.Connected boolean
 	.Disconnect (self: T) -> ()
+	.Destroy ((self: T) -> ())?
 	@tag Metatable
 ]=]
 type ConnectionLikeMetatable<T = any> = typeof(setmetatable({}, {} :: ConnectionLike<T>))
 
 --[=[
 	@within Trove
-	@interface SignalLike<T = any, A... = ...any>
-	.Connect (self: any, callback: (A...) -> ()) -> ConnectionLike
-	.Once (self: any, callback: (A...) -> ()) -> ConnectionLike
+	@interface SignalLike<T... = ...any>
+	.Connect (self: any, callback: (T...) -> ()) -> ConnectionLike
+	.Once (self: any, callback: (T...) -> ()) -> ConnectionLike
 ]=]
 type SignalLike<T... = ...any> = {
 	Connect: (self: any, callback: (T...) -> ()) -> ConnectionLike,
@@ -35,9 +37,9 @@ type SignalLike<T... = ...any> = {
 
 --[=[
 	@within Trove
-	@interface SignalLikeMetatable<T = any, A... = ...any>
-	.Connect (self: T, callback: (T...) -> ()) -> ConnectionLike
-	.Once (self: T, callback: (T...) -> ()) -> ConnectionLike
+	@interface SignalLikeMetatable<T... = ...any>
+	.Connect (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike
+	.Once (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike
 	@tag Metatable
 ]=]
 type SignalLikeMetatable<T... = ...any> = typeof(setmetatable({}, {} :: {
@@ -167,7 +169,7 @@ type CloneableMetatable<T = any> = typeof(setmetatable({}, {} :: Cloneable<T>))
 
 --[=[
 	@within Trove
-	@type Trackable Instance | RBXScriptConnection | ConnectionLike | ConnectLikeMetatable | PromiseLike | PromiseLikeMetatable | thread | ((...any) -> ...any) | Destroyable | DestroyableMetatable | DestroyableLowercase | DestroyableLowercaseMetatable | Disconnectable | DisconnectableMetatable | DisconnectableLowercase | DisconnectableLowercaseMetatable | SignalLike | SignalLikeMetatable
+	@type Trackable<T = any, A... = ...any> Instance | RBXScriptConnection | ConnectionLike<T> | ConnectLikeMetatable<T> | PromiseLike<T> | PromiseLikeMetatable<T> | thread | ((...any) -> ...any) | Destroyable<T> | DestroyableMetatable<T> | DestroyableLowercase<T> | DestroyableLowercaseMetatable<T> | Disconnectable<T> | DisconnectableMetatable<T> | DisconnectableLowercase<T> | DisconnectableLowercaseMetatable<T> | SignalLike<A...> | SignalLikeMetatable<A...>
 	Represents all trackable objects by Trove.
 ]=]
 export type Trackable<T = any, A... = ...any> =
@@ -235,7 +237,7 @@ local function getObjectCleanupFunction(object: any, cleanupMethod: string?)
 	error(`failed to get cleanup function for object {t}: {object}`, 3)
 end
 
-local function cleanupObject(object: any, cleanupMethod: string?)
+function Trove._cleanupObject(self: Trove, object: any, cleanupMethod: string?)
 	if cleanupMethod == FN_MARKER then
 		task.spawn(object)
 	elseif cleanupMethod == THREAD_MARKER then
@@ -245,7 +247,7 @@ local function cleanupObject(object: any, cleanupMethod: string?)
 	end
 end
 
-local function findAndRemoveFromObjects(self: Trove, object: any, cleanup: boolean): boolean
+function Trove._findAndRemoveFromObjects(self: Trove, object: any, cleanup: boolean): boolean
 	local objects = self._objects
 
 	for i, obj in objects do
@@ -255,7 +257,7 @@ local function findAndRemoveFromObjects(self: Trove, object: any, cleanup: boole
 			objects[n] = nil
 
 			if cleanup then
-				cleanupObject(obj[1], obj[2])
+				self:_cleanupObject(obj[1], obj[2])
 			end
 
 			return true
@@ -305,7 +307,7 @@ end
 --[=[
 	@method Add
 	@within Trove
-	@param object any -- Object to track
+	@param object Trackable<T> -- Object to track
 	@param cleanupMethod string? -- Optional cleanup name override
 	@return object: any
 	Adds an object to the trove. Once the trove is cleaned or
@@ -366,7 +368,8 @@ end
 --[=[
 	@method Clone
 	@within Trove
-	@return Instance
+	@return T
+	@param instance Instance | Cloneable<T> | CloneableMetatable<T>
 	Clones the given instance and adds it to the trove. Shorthand for
 	`trove:Add(instance:Clone())`.
 
@@ -566,7 +569,7 @@ function Trove.AddPromise<T>(self: Trove, promise: PromiseLike<T>): T
 				return
 			end
 
-			findAndRemoveFromObjects(self, confirmedPromise, false)
+			self:_findAndRemoveFromObjects(confirmedPromise, false)
 		end)
 
 		self:Add(confirmedPromise, "cancel")
@@ -578,7 +581,7 @@ end
 --[=[
 	@method Remove
 	@within Trove
-	@param object any
+	@param object Trackable<T>
 	Removes the object from the Trove and cleans it up. To remove without
 	cleaning, use the `Pop` method instead.
 
@@ -593,13 +596,13 @@ function Trove.Remove<T>(self: Trove, object: Trackable<T>): boolean
 		error("cannot call trove:Remove() while cleaning", 2)
 	end
 
-	return findAndRemoveFromObjects(self, object, true)
+	return self:_findAndRemoveFromObjects(self, object, true)
 end
 
 --[=[
 	@method Pop
 	@within Trove
-	@param object any
+	@param object Trackable<T>
 	Removes the object from the Trove, but does _not_ clean it up. To
 	clean up the object on removal, use the `Remove` method instead.
 
@@ -615,7 +618,7 @@ function Trove.Pop<T>(self: Trove, object: Trackable<T>): boolean
 		error("cannot call trove:Pop() while cleaning", 2)
 	end
 
-	return findAndRemoveFromObjects(self, object, false)
+	return self:_findAndRemoveFromObjects(self, object, false)
 end
 
 --[=[
@@ -667,7 +670,7 @@ function Trove.Clean(self: Trove)
 	self._cleaning = true
 
 	for _, obj in self._objects do
-		cleanupObject(obj[1], obj[2])
+		self:_cleanupObject(obj[1], obj[2])
 	end
 
 	table.clear(self._objects)

--- a/modules/trove/init.luau
+++ b/modules/trove/init.luau
@@ -1,19 +1,22 @@
 --!strict
 local RunService = game:GetService("RunService")
 
+local Trove = {}
+Trove.__index = Trove
 
 --[=[
 	@class Trove
 	A Trove is helpful for tracking any sort of object during
 	runtime that needs to get cleaned up at some point.
 ]=]
-local Trove = {}
-Trove.__index = Trove
 
-export type Trove = typeof(setmetatable({} :: {
-	_objects: { any },
-	_cleaning: boolean,
-}, Trove))
+export type Trove = typeof(setmetatable(
+	{} :: {
+		_objects: { any },
+		_cleaning: boolean,
+	},
+	Trove
+))
 
 --[=[
 	@within Trove
@@ -81,21 +84,19 @@ type SignalLike<T... = ...any> = {
 	.Once (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike
 	@tag Metatable
 ]=]
-type SignalLikeMetatable<T... = ...any> = typeof(setmetatable({}, {} :: {
-	Connect: (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike,
-	Once: (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike,
-}))
+type SignalLikeMetatable<T... = ...any> = typeof(setmetatable(
+	{},
+	{} :: {
+		Connect: (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike,
+		Once: (self: SignalLikeMetatable<T...>, callback: (T...) -> ()) -> ConnectionLike,
+	}
+))
 
 --[=[
 	@within Trove
-	@type PromiseLikeStatus
+	@type PromiseLikeStatus "Started" | "Resolved" | "Rejected" | "Cancelled" | string
 ]=]
-type PromiseLikeStatus =
-	| "Started"
-	| "Resolved"
-	| "Rejected"
-	| "Cancelled"
-	| string
+type PromiseLikeStatus = "Started" | "Resolved" | "Rejected" | "Cancelled" | string
 
 --[=[
 	@within Trove
@@ -205,7 +206,6 @@ type Cloneable<T = any> = {
 	.Clone (self: T) -> T
 ]=]
 type CloneableMetatable<T = any> = typeof(setmetatable({}, {} :: Cloneable<T>))
-
 
 local FN_MARKER = newproxy()
 local THREAD_MARKER = newproxy()
@@ -397,6 +397,7 @@ function Trove.Construct<T, A...>(self: Trove, class: Constructable<T, A...>, ..
 		error("Cannot call trove:Construct() while cleaning", 2)
 	end
 
+	-- stylua: ignore
 	local object = if type(class) == "table"
 		then class.new(...)
 		else class(...)


### PR DESCRIPTION
## Summary

This commit extends on #200. The recent changes to support `--!strict` in Trove were good in principle, but had several problems because of Luau being Luau. This pull request attempts to resolve a lot of these problems.

Unlike before, this allows the _actual_ metatable-backed Trove type to be exported!

## What was changed?

I've removed the manually-defined `Trove` type in favor of renaming the `TroveInternal` type to `Trove`. Function signatures are now derived as they are written in the `Trove` table. I also updated many of the types in `Trackable` to be generic-backed (defaults set to `any` and `...any` when possible), which allows for `T` to be slotted in as the value of `self`. It _just works™_!

Hard to say is this is 100% bug-free, but I've been thoroughly checking against my `--!strict` codebase and the results are extremely promising!

<img width="1250" height="621" alt="image" src="https://github.com/user-attachments/assets/e6562403-52b6-46b7-a149-1a274c62699d" />

<br/>
<br/>

<img width="1556" height="473" alt="image" src="https://github.com/user-attachments/assets/4e0d0e30-eeda-4045-9837-3490db1bfd70" />

<br/>
<br/>

<img width="1076" height="248" alt="image" src="https://github.com/user-attachments/assets/6f2381f4-e23c-4150-b3c8-21b1621d53e0" />
