### PR TITLE
Patch: Correct checkout hang and permission issues for forked PRs.

### DIFF
--- a/.github/workflows/files.yaml
+++ b/.github/workflows/files.yaml
@@ -32,5 +32,5 @@ jobs:
           git add README.md
           if ! git diff --cached --quiet; then
             git commit -m "Automated file generation"
-            git push origin main
+            git push
           fi

--- a/.github/workflows/files.yaml
+++ b/.github/workflows/files.yaml
@@ -1,7 +1,7 @@
 name: Generated Files
 
 on:
-  pull_request:
+  push:
     branches:
       - 'main'
 
@@ -14,15 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
+
       - name: Install Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+
       - run: python build_readme.py
       - run: python build_list.py
-      - name: Git
+
+      - name: Git Push
         shell: bash
         run: |
           git config user.name "github-actions[bot]"
@@ -31,5 +32,5 @@ jobs:
           git add README.md
           if ! git diff --cached --quiet; then
             git commit -m "Automated file generation"
-            git push
+            git push origin main
           fi

--- a/.github/workflows/files.yaml
+++ b/.github/workflows/files.yaml
@@ -3,7 +3,7 @@ name: Generated Files
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 
 permissions:
   contents: write


### PR DESCRIPTION
The previous workflow used `github.head_ref`, causing the CI to hang or fail on forked PRs, as it couldn't correctly resolve branch names across repositories. It also struggled with permission errors when trying to push back to contributors' forks.

This PR addresses and refactors the `Generated Files` workflow into a post-merge version cleaner model:
* Switched to `on: push` `->` `main`. This ensures the automation only runs once code has been merged.
* By running directly on the base repository, we eliminate cross-repository permission errors, and the significant checkout hang.
* Keeping this ensures that the `README.md` and `filelist.json` files are always in synchronization with the latest code on `main`, even if a contributor forgets to update them locally.

I verified on forks that the scripts executed successfully and that the bot can push the commit directly to the repository without authentication hurdles! :D