### PR TITLE
Clamped alpha in RotateTowards

### DIFF
--- a/modules/quaternion/init.luau
+++ b/modules/quaternion/init.luau
@@ -310,7 +310,7 @@ function Quaternion.RotateTowards(self: Quaternion, other: Quaternion, maxRadian
 		return self
 	end
 
-	local alpha = maxRadiansDelta / angle
+	local alpha = math.min(maxRadiansDelta / angle, 1)
 
 	return self:Slerp(other, alpha)
 end


### PR DESCRIPTION
Clamped alpha in RotateTowards so max rotation speeds that are very large compared to the angle needed to lerp across don't overshoot